### PR TITLE
Update 3 03_operators.md

### DIFF
--- a/03_Day_Operators/03_operators.md
+++ b/03_Day_Operators/03_operators.md
@@ -164,7 +164,7 @@ print('Area of a circle:', area_of_circle)
 length = 10
 width = 20
 area_of_rectangle = length * width
-print('Area of rectangle:', area_of_width)
+print('Area of rectangle:', area_of_rectangle)
 
 # Calculating a weight of an object
 mass = 75


### PR DESCRIPTION
Changed print('Area of rectangle:', area_of_width) to print('Area of rectangle:', area_of_rectangle) as area_of_width is not the declared variable associated with the print statement.