### PR TITLE
Fix: Usage example of index() was a duplicate of the usage example of find() in day_4.py

### DIFF
--- a/04_Day_Strings/day_4.py
+++ b/04_Day_Strings/day_4.py
@@ -133,8 +133,9 @@ print(result) # The area of circle with 10 is 314.0
 
 # index(): Returns the index of substring
 challenge = 'thirty days of python'
-print(challenge.find('y'))  # 5
-print(challenge.find('th')) # 0
+sub_string = 'da'
+print(challenge.index(sub_string))  # 7
+print(challenge.index(sub_string, 9)) # error
 
 # isalnum(): Checks alphanumeric character
 


### PR DESCRIPTION
Current usage example of find():
```python
# find(): Returns the index of first occurrence of substring
challenge = 'thirty days of python'
print(challenge.find('y'))  # 5
print(challenge.find('th')) # 0  
```
Example of find() is found where the example of index should be.
```diff
# index(): Returns the index of substring
challenge = 'thirty days of python'
- print(challenge.find('y'))  # 5
- print(challenge.find('th')) # 0
+ sub_string = 'da'
+ print(challenge.index(sub_string))  # 7
+ print(challenge.index(sub_string, 9)) # error
```
The duplicate example is removed and replaced with the `index()` example from the `String Methods` section of `04_strings.md`.