### PR TITLE
Fix: 'start' duplicate in 03_operators.md and removed unnecessary parenthesis

### DIFF
--- a/03_Day_Operators/03_operators.md
+++ b/03_Day_Operators/03_operators.md
@@ -150,7 +150,7 @@ print('division: ', div)
 print('remainder: ', remainder)
 ```
 
-Let's start start connecting the dots and start making use of what we already know to calculate (area, volume, weight, perimeter, distance, force)
+Let's start connecting the dots and making use of what we already know to calculate area, volume, weight, perimeter, distance, and force.
 
 **Example:**
 


### PR DESCRIPTION
closes #88 
Fixed sentence to be more concise and removed duplicate 'start' typo.