### PR TITLE
minor fix in the day 02 md file - removing a print statements

### DIFF
--- a/02_Day_Variables_builtin_functions/02_variables_builtin_functions.md
+++ b/02_Day_Variables_builtin_functions/02_variables_builtin_functions.md
@@ -230,7 +230,6 @@ print('num_float', float(num_str))  # 10.6
 
 # str to list
 first_name = 'Asabeneh'
-print(first_name)
 print(first_name)                    # 'Asabeneh'
 first_name_to_list = list(first_name)
 print(first_name_to_list)            # ['A', 's', 'a', 'b', 'e', 'n', 'e', 'h']


### PR DESCRIPTION
In the 'casting' section of 'Checking Data types and Casting', first_name is printed twice. So, removing one.