### PR TITLE
line 186 readme.md syntaxerror

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,8 @@ Lets do some maths first before we write any python code:
 - 3 - 2 = 1
 - 3 \* 2 = 6
 - 3 / 2 = 1.5
-- 3 ^ 2 = 3 x 3 = 9
+- 3 ^ 2 = 1
+- 3 \* 3 = 9
 
 In python we have the following additional operations:
 


### PR DESCRIPTION
Current readme section for day 1 has improper syntax
```
>>> 3 ^ 2 = 3 x 3
  File "<stdin>", line 1
    3 ^ 2 = 3 x 3
    ^
SyntaxError: cannot assign to operator
>>> 3 ^ 2 = 3 x 3 = 9
  File "<stdin>", line 1
    3 ^ 2 = 3 x 3 = 9
    ^
SyntaxError: cannot assign to operator
```

Unless I misunderstood this as being intentional (to force people to debug), if so then disregard. :)