### PR TITLE
fix: Change the syntax of not equal operator

### DIFF
--- a/09_Day_Conditionals/09_conditionals.md
+++ b/09_Day_Conditionals/09_conditionals.md
@@ -169,7 +169,7 @@ if condition and condition:
 a = 0
 if a > 0 and a % 2 == 0:
         print('A is an even and positive integer')
-elif a > 0 and a % 2 != = 0:
+elif a > 0 and a % 2 != 0:
      print('A is a positive integer')
 elif a == 0:
     print('A is zero')


### PR DESCRIPTION
Fixes a syntax error caused by an extra equal sign and a blank space.

Resolves: #154