### PR TITLE
corrected while loop code

### DIFF
--- a/10_Day_Loops/10_loops.md
+++ b/10_Day_Loops/10_loops.md
@@ -11,6 +11,7 @@
 <a href="https://www.linkedin.com/in/asabeneh/" target="_blank">Asabeneh Yetayeh</a><br>
 <small> Second Edition: July, 2021</small>
 </sub>
+
 </div>
 
 [<< Day 9](../09_Day_Conditionals/09_conditionals.md) | [Day 11 >>](../11_Day_Functions/11_functions.md)
@@ -85,7 +86,6 @@ else:
 
 The above loop condition will be false when count is 5 and the loop stops, and execution starts the else statement. As a result 5 will be printed.
 
-
 ### Break and Continue - Part 1
 
 - Break: We use break when we like to get out of or stop the loop.
@@ -126,13 +126,13 @@ while condition:
 ```py
 count = 0
 while count < 5:
+    count = count + 1
     if count == 3:
         continue
     print(count)
-    count = count + 1
 ```
 
-The above while loop only prints 0, 1, 2 and 4 (skips 3).
+The above while loop only prints 0, 1, 2, 4 and 5 (skips 3).
 
 ### For Loop
 
@@ -284,7 +284,7 @@ for number in numbers:
 print('outside the loop')
 ```
 
-In the example above, if the number equals 3, the step *after* the condition (but inside the loop) is skipped and the execution of the loop continues if there are any iterations left.
+In the example above, if the number equals 3, the step _after_ the condition (but inside the loop) is skipped and the execution of the loop continues if there are any iterations left.
 
 ### The Range Function
 
@@ -292,7 +292,7 @@ The _range()_ function is used list of numbers. The _range(start, end, step)_ ta
 Creating sequences using range
 
 ```py
-lst = list(range(11)) 
+lst = list(range(11))
 print(lst) # [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 st = set(range(1, 11))    # 2 arguments indicate start and end of the sequence, step set to default 1
 print(st) # {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
@@ -431,26 +431,26 @@ for number in range(6):
 6. Iterate through the list, ['Python', 'Numpy','Pandas','Django', 'Flask'] using a for loop and print out the items.
 7. Use for loop to iterate from 0 to 100 and print only even numbers
 8. Use for loop to iterate from 0 to 100 and print only odd numbers
-   
+
 ### Exercises: Level 2
-    
+
 1.  Use for loop to iterate from 0 to 100 and print the sum of all numbers.
 
-   ```sh
-   The sum of all numbers is 5050.
-   ```
+```sh
+The sum of all numbers is 5050.
+```
 
 1. Use for loop to iterate from 0 to 100 and print the sum of all evens and the sum of all odds.
 
-    ```sh
-    The sum of all evens is 2550. And the sum of all odds is 2500.
-    ```
+   ```sh
+   The sum of all evens is 2550. And the sum of all odds is 2500.
+   ```
 
 ### Exercises: Level 3
 
 1. Go to the data folder and use the [countries.py](https://github.com/Asabeneh/30-Days-Of-Python/blob/master/data/countries.py) file. Loop through the countries and extract all the countries containing the word _land_.
 1. This is a fruit list, ['banana', 'orange', 'mango', 'lemon'] reverse the order using loop.
-2. Go to the data folder and use the [countries_data.py](https://github.com/Asabeneh/30-Days-Of-Python/blob/master/data/countries-data.py) file. 
+1. Go to the data folder and use the [countries_data.py](https://github.com/Asabeneh/30-Days-Of-Python/blob/master/data/countries-data.py) file.
    1. What are the total number of languages in the data
    2. Find the ten most spoken languages from the data
    3. Find the 10 most populated countries in the world


### PR DESCRIPTION
### In the python while loop example the code will only output 1,2,3  because the code after the ```continue``` statement will never be reached when ```count ===3 ``` 

```
count = 0
while count < 5:
    count = count + 1
    if count == 3:
        continue
    print(count)
```

## Here is my proposed code, i've tested it and it works.

```
count = 0
while count < 5:
    count = count + 1
    if count == 3:
        continue
    print(count)

# The above while loop only prints 0, 1, 2, 4 and 5 (skips 3).

```