### PR TITLE
Update 17_exception_handling.md

### DIFF
--- a/17_Day_Exception_handling/17_exception_handling.md
+++ b/17_Day_Exception_handling/17_exception_handling.md
@@ -225,7 +225,7 @@ def packing_person_info(**kwargs):
     # print(type(kwargs))
 	# Printing dictionary items
     for key in kwargs:
-        print("{key} = {kwargs[key]}")
+        print(f"{key} = {kwargs[key]}")
     return kwargs
 
 print(packing_person_info(name="Asabeneh",


### PR DESCRIPTION
### `f` missing in `f-string` in `first example of packing dictionaries`

**`Section`**: **Packing dictionaries**

**`Proposed change:`**
def packing_person_info(**kwargs):
	# Printing dictionary items
    for key in kwargs:

>         print(`f`"{key} = {kwargs[key]}")      # This is the line to be updated

    return kwargs

print(packing_person_info(name="Asabeneh",
      country="Finland", city="Helsinki", age=250))

**`What's missing`**:       print(`f`"{key} = {kwargs[key]}")

**`Reason`:** If we don't include **`f`** before the string it won't print the key-value pairs.