### PR TITLE
Update 18_regular_expressions.md

### DIFF
--- a/18_Day_Regular_expressions/18_regular_expressions.md
+++ b/18_Day_Regular_expressions/18_regular_expressions.md
@@ -106,7 +106,7 @@ The string does not string with *I like to teach*, therefore there was no match 
 
 ```py
 # syntax
-re.match(substring, string, re.I)
+re.search(substring, string, re.I)
 # substring is a pattern, string is the text we look for a pattern , re.I is case ignore flag
 ```
 


### PR DESCRIPTION
Updated syntax for `search`: Replaced `re.match()` to `re.search()`