### PR TITLE
Typo in day 17

### DIFF
--- a/17_Day_Exception_handling/17_exception_handling.md
+++ b/17_Day_Exception_handling/17_exception_handling.md
@@ -225,7 +225,7 @@ def packing_person_info(**kwargs):
     # print(type(kwargs))
 	# Printing dictionary items
     for key in kwargs:
-        print("{key} = {kwargs[key]}")
+        print(f'{key} = {kwargs[key]}')
     return kwargs
 
 print(packing_person_info(name="Asabeneh",


### PR DESCRIPTION
There is a typo in Packing Dictionaries inside the print() function.

Before the fix, the functions print this:

```
{key} = {kwargs[key]}
{key} = {kwargs[key]}
{key} = {kwargs[key]}
{key} = {kwargs[key]}
{'name': 'Asabeneh', 'country': 'Finland', 'city': 'Helsinki', 'age': 250}
```

After the fix, the functions prnt this:

```
name = Asabeneh
country = Finland
city = Helsinki
age = 250
{'name': 'Asabeneh', 'country': 'Finland', 'city': 'Helsinki', 'age': 250}
```