### PR TITLE
Infinite loop in continue example

### DIFF
--- a/10_Day_Loops/10_loops.md
+++ b/10_Day_Loops/10_loops.md
@@ -127,6 +127,7 @@ while condition:
 count = 0
 while count < 5:
     if count == 3:
+        count = count + 1
         continue
     print(count)
     count = count + 1


### PR DESCRIPTION
The condition of (if count ==  3) makes an infinite loop because can't increase the count.