### PR TITLE
Fix URL in link

### DIFF
--- a/16_Day_Python_date_time/16_python_datetime.md
+++ b/16_Day_Python_date_time/16_python_datetime.md
@@ -105,7 +105,7 @@ Here are all the _strftime_ symbols we use to format time. An example of all the
 ![strftime](../images/strftime.png)
 
 ### String to Time Using *strptime*
-Here is a [documentation](https://www.programiz.com/python-programming/datetime/strptimet) hat helps to understand the format. 
+Here is a [documentation](https://www.programiz.com/python-programming/datetime/strptime) hat helps to understand the format. 
 
 ```py
 from datetime import datetime


### PR DESCRIPTION
I noticed a link that led to a 404, which could be easily corrected by removing the last character of the URL.