### PR TITLE
bugfix: fix 03_operators.md number error

### DIFF
--- a/03_Day_Operators/03_operators.md
+++ b/03_Day_Operators/03_operators.md
@@ -75,7 +75,7 @@ print('Division: ', 7 / 2)        # 3.5
 print('Division without the remainder: ', 7 // 2)   # 3,  gives without the floating number or without the remaining
 print ('Division without the remainder: ',7 // 3)   # 2
 print('Modulus: ', 3 % 2)         # 1, Gives the remainder
-print('Exponentiation: ', 2 ** 3) # 9 it means 2 * 2 * 2
+print('Exponentiation: ', 2 ** 3) # 8 it means 2 * 2 * 2
 ```
 
 **Example:Floats**


### PR DESCRIPTION
 change file: 03_operators.md (line:78)
```py
print('Exponentiation: ', 2 ** 3) # 9 it means 2 * 2 * 2
```
to
```py
print('Exponentiation: ', 2 ** 3) # 8 it means 2 * 2 * 2
```