### PR TITLE
Fix typo in 08_dictionaries.md

### DIFF
--- a/08_Day_Dictionaries/08_dictionaries.md
+++ b/08_Day_Dictionaries/08_dictionaries.md
@@ -60,7 +60,7 @@ person = {
     'last_name':'Yetayeh',
     'age':250,
     'country':'Finland',
-    'is_marred':True,
+    'is_married':True,
     'skills':['JavaScript', 'React', 'Node', 'MongoDB', 'Python'],
     'address':{
         'street':'Space street',


### PR DESCRIPTION
There is a typo in line 63. The property "is_marred" of person dictionary an then this line "del person['is_married']  # Removes the is_married item" fails