### PR TITLE
Fix Chinese navigation links after Day 7

### DIFF
--- a/Chinese/07_sets.md
+++ b/Chinese/07_sets.md
@@ -14,7 +14,7 @@
 
 </div>
 
-[<< 第 6 天](../06_Day_Tuples/06_tuples.md) | [第 8 天 >>](../08_Day_Dictionaries/08_dictionaries.md)
+[<< 第 6 天](./06_tuples.md) | [第 8 天 >>](./08_dictionaries.md)
 
 ![30DaysOfPython](../images/30DaysOfPython_banner3@2x.png)
 
@@ -428,4 +428,4 @@ age = [22, 19, 24, 25, 26, 24, 25, 24]
 
 🎉 恭喜！ 🎉
 
-[<< 第 6 天](../06_Day_Tuples/06_tuples.md) | [第 8 天 >>](../08_Day_Dictionaries/08_dictionaries.md)
+[<< 第 6 天](./06_tuples.md) | [第 8 天 >>](./08_dictionaries.md)

--- a/Chinese/08_dictionaries.md
+++ b/Chinese/08_dictionaries.md
@@ -14,7 +14,7 @@
 
 </div>
 
-[<< 第 7 天 ](../07_Day_Sets/07_sets.md) | [第 9 天 >>](../09_Day_Conditionals/09_conditionals.md)
+[<< 第 7 天](./07_sets.md) | [第 9 天 >>](./09_conditionals.md)
 
 ![30 天 Python 学习](../images/30DaysOfPython_banner3@2x.png)
 
@@ -340,4 +340,4 @@ print(values) # dict_values(['value1', 'value2', 'value3', 'value4'])
 
 🎉 恭喜你! 🎉
 
-[<< 第 7 天 ](../07_Day_Sets/07_sets.md) | [第 9 天 >>](../09_Day_Conditionals/09_conditionals.md)
+[<< 第 7 天](./07_sets.md) | [第 9 天 >>](./09_conditionals.md)

--- a/Chinese/09_conditionals.md
+++ b/Chinese/09_conditionals.md
@@ -14,7 +14,7 @@
 
 </div>
 
-[<< 第 8 天](../08_Day_Dictionaries/08_dictionaries.md) | [第 10 天 >>](../10_Day_Loops/10_loops.md)
+[<< 第 8 天](./08_dictionaries.md) | [第 10 天 >>](./10_loops.md)
 
 ![30DaysOfPython](../images/30DaysOfPython_banner3@2x.png)
 
@@ -281,4 +281,4 @@ Asabeneh Yetayeh住在芬兰。他已婚。
 
 🎉 恭喜！ 🎉
 
-[<< 第 8 天](../08_Day_Dictionaries/08_dictionaries.md) | [第 10 天 >>](../10_Day_Loops/10_loops.md)
+[<< 第 8 天](./08_dictionaries.md) | [第 10 天 >>](./10_loops.md)

--- a/Chinese/10_loops.md
+++ b/Chinese/10_loops.md
@@ -14,7 +14,7 @@
 
 </div>
 
-[<<第九天](../Chinese/09_conditionals.md) | [第十一天>>](../Chinese/11_functions.md)
+[<< 第 9 天](./09_conditionals.md) | [第 11 天 >>](./11_functions.md)
 
 ![30DaysOfPython](../images/30DaysOfPython_banner3@2x.png)
 
@@ -448,4 +448,4 @@ for number in range(6):
 
 🎉 恭喜！ 🎉
 
-[<< Day 9](./09_conditionals.md) | [Day 11 >>](./11_functions.md)
+[<< 第 9 天](./09_conditionals.md) | [第 11 天 >>](./11_functions.md)

--- a/Chinese/11_functions.md
+++ b/Chinese/11_functions.md
@@ -14,7 +14,7 @@
 
 </div>
 
-[<< 第 10 天](../10_Day_Loops/10_loops.md) | [第 12 天 >>](../12_Day_Modules/12_modules.md)
+[<< 第 10 天](./10_loops.md) | [第 12 天 >>](./12_modules.md)
 
 ![30DaysOfPython](../images/30DaysOfPython_banner3@2x.png)
 
@@ -455,4 +455,4 @@ print(sum_all_numbers(100)) # 5050
 
 🎉 恭喜! 🎉
 
-[<< 第 10 天](../10_Day_Loops/10_loops.md) | [第 12 天 >>](../12_Day_Modules/12_modules.md)
+[<< 第 10 天](./10_loops.md) | [第 12 天 >>](./12_modules.md)

--- a/Chinese/12_modules.md
+++ b/Chinese/12_modules.md
@@ -15,7 +15,7 @@
 </div>
 </div>
 
-[<< 第 11 天](../11_Day_Functions/11_functions.md) | [第 13 天>>](../13_Day_List_comprehension/13_list_comprehension.md)
+[<< 第 11 天](./11_functions.md) | [第 13 天 >>](./13_list_comprehension.md)
 
 ![30DaysOfPython](../images/30DaysOfPython_banner3@2x.png)
 
@@ -300,4 +300,4 @@ print(rgb_color_gen())
 
 🎉 恭喜！ 🎉
 
-[<< 第 11 天](../11_Day_Functions/11_functions.md) | [第 13 天>>](../13_Day_List_comprehension/13_list_comprehension.md)
+[<< 第 11 天](./11_functions.md) | [第 13 天 >>](./13_list_comprehension.md)

--- a/Chinese/13_list_comprehension.md
+++ b/Chinese/13_list_comprehension.md
@@ -15,7 +15,7 @@
 </div>
 </div>
 
-[<< 第 12 天](../12_Day_Modules/12_modules.md) | [第 14 天>>](../14_Day_Higher_order_functions/14_higher_order_functions.md)
+[<< 第 12 天](./12_modules.md) | [第 14 天 >>](./14_higher_order_functions.md)
 
 ![30DaysOfPython](../images/30DaysOfPython_banner3@2x.png)
 
@@ -205,4 +205,4 @@ print(two_power_of_five)  # 32
 
 🎉 祝贺你！🎉
 
-[<< 第 12 天](../12_Day_Modules/12_modules.md) | [第 14 天>>](../14_Day_Higher_order_functions/14_higher_order_functions.md)
+[<< 第 12 天](./12_modules.md) | [第 14 天 >>](./14_higher_order_functions.md)

--- a/Chinese/14_higher_order_functions.md
+++ b/Chinese/14_higher_order_functions.md
@@ -14,7 +14,7 @@
 
 </div>
 
-[<< 第 13 天](../13_Day_List_comprehension/13_list_comprehension.md) | [第 15 天>>](../15_Day_Python_type_errors/15_python_type_errors.md)
+[<< 第 13 天](./13_list_comprehension.md) | [第 15 天 >>](./15_python_type_errors_cn.md)
 
 ![30DaysOfPython](../images/30DaysOfPython_banner3@2x.png)
 
@@ -365,4 +365,4 @@ numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 🎉 恭喜你！ 🎉
 
-[<< 第 13 天](../13_Day_List_comprehension/13_list_comprehension.md) | [第 15 天>>](../15_Day_Python_type_errors/15_python_type_errors.md)
+[<< 第 13 天](./13_list_comprehension.md) | [第 15 天 >>](./15_python_type_errors_cn.md)

--- a/Chinese/15_python_type_errors_cn.md
+++ b/Chinese/15_python_type_errors_cn.md
@@ -341,4 +341,4 @@ ZeroDivisionError: division by zero
 
 🎉 恭喜！🎉
 
-[<< 第14天](./14_higher_order_functions.md) | [第16天 >>](./16_python_datetime_cn.md) 
+[<< 第 14 天](./14_higher_order_functions.md) | [第 16 天 >>](./16_python_datetime_cn.md) 

--- a/Chinese/16_python_datetime_cn.md
+++ b/Chinese/16_python_datetime_cn.md
@@ -189,4 +189,4 @@ t3 = 86 days, 22:56:50
 
 🎉 恭喜！🎉
 
-[<< 第15天](./15_Day_Python_type_errors/15_python_type_errors_cn.md) | [第17天 >>](./17_Day_Exception_handling/17_exception_handling_cn.md) 
+[<< 第 15 天](./15_python_type_errors_cn.md) | [第 17 天 >>](./17_exception_handling_cn.md) 

--- a/Chinese/17_exception_handling_cn.md
+++ b/Chinese/17_exception_handling_cn.md
@@ -282,4 +282,4 @@ print(fruits_and_veges)
 
 🎉 恭喜！🎉
 
-[<< 第16天](./16_Day_Python_date_time/16_python_datetime_cn.md) | [第18天 >>](./18_Day_Regular_expressions/18_regular_expressions_cn.md) 
+[<< 第 16 天](./16_python_datetime_cn.md) | [第 18 天 >>](./18_regular_expressions_cn.md) 

--- a/Chinese/18_regular_expressions_cn.md
+++ b/Chinese/18_regular_expressions_cn.md
@@ -414,4 +414,4 @@ alex@yahoo
 
 🎉 恭喜！🎉
 
-[<< 第17天](./17_Day_Exception_handling/17_exception_handling_cn.md) | [第19天 >>](./19_Day_File_handling/19_file_handling_cn.md) 
+[<< 第 17 天](./17_exception_handling_cn.md) | [第 19 天 >>](./19_file_handling_cn.md) 

--- a/Chinese/19_file_handling_cn.md
+++ b/Chinese/19_file_handling_cn.md
@@ -546,4 +546,4 @@ Python
 
 🎉 恭喜！🎉
 
-[<< 第18天](./18_Day_Regular_expressions/18_regular_expressions_cn.md) | [第20天 >>](./20_Day_Python_package_manager/20_python_package_manager_cn.md) 
+[<< 第 18 天](./18_regular_expressions_cn.md) | [第 20 天 >>](./20_python_package_manager_cn.md) 

--- a/Chinese/20_python_package_manager_cn.md
+++ b/Chinese/20_python_package_manager_cn.md
@@ -349,4 +349,4 @@ print(greet.greet_person('张', '三'))
 
 🎉 恭喜！🎉
 
-[<< 第19天](./19_Day_File_handling/19_file_handling_cn.md) | [第21天 >>](./21_Day_Classes_and_objects/21_classes_and_objects_cn.md) 
+[<< 第 19 天](./19_file_handling_cn.md) | [第 21 天 >>](./21_classes_and_objects_cn.md) 

--- a/Chinese/21_classes_and_objects_cn.md
+++ b/Chinese/21_classes_and_objects_cn.md
@@ -416,4 +416,4 @@ juice: orange
 
 🎉 恭喜！🎉
 
-[<< 第20天](./20_Day_Python_package_manager/20_python_package_manager_cn.md) | [第22天 >>](./22_Day_Web_scraping/22_web_scraping_cn.md) 
+[<< 第 20 天](./20_python_package_manager_cn.md) | [第 22 天 >>](./22_web_scraping_cn.md) 

--- a/Chinese/22_web_scraping_cn.md
+++ b/Chinese/22_web_scraping_cn.md
@@ -86,4 +86,4 @@ for td in table.find('tr').find_all('td'):
 
 🎉 恭喜！🎉
 
-[<< 第21天](./21_Day_Classes_and_objects/21_classes_and_objects_cn.md) | [第23天 >>](./23_Day_Virtual_environment/23_virtual_environment_cn.md) 
+[<< 第 21 天](./21_classes_and_objects_cn.md) | [第 23 天 >>](./23_virtual_environment_cn.md) 

--- a/Chinese/23_virtual_environment_cn.md
+++ b/Chinese/23_virtual_environment_cn.md
@@ -94,4 +94,4 @@ Werkzeug==0.16.0
 
 🎉 恭喜！🎉
 
-[<< 第22天](./22_Day_Web_scraping/22_web_scraping_cn.md) | [第24天 >>](./24_Day_Statistics/24_statistics_cn.md) 
+[<< 第 22 天](./22_web_scraping_cn.md) | [第 24 天 >>](./24_statistics_cn.md) 

--- a/Chinese/24_statistics_cn.md
+++ b/Chinese/24_statistics_cn.md
@@ -586,4 +586,4 @@ print('平均值：', numpy_array_from_list.mean())
 
 🎉 恭喜！🎉
 
-[<< 第23天](./23_Day_Virtual_environment/23_virtual_environment_cn.md) | [第25天 >>](./25_Day_Pandas/25_pandas_cn.md) 
+[<< 第 23 天](./23_virtual_environment_cn.md) | [第 25 天 >>](./25_pandas_cn.md) 

--- a/Chinese/25_pandas_cn.md
+++ b/Chinese/25_pandas_cn.md
@@ -548,4 +548,4 @@ print(df[(df['age'] > 20) & (df['在职'] == True)])
 
 🎉 恭喜！🎉
 
-[<< 第24天](./24_Day_Statistics/24_statistics_cn.md) | [第26天 >>](./26_Day_Python_web/26_python_web_cn.md) 
+[<< 第 24 天](./24_statistics_cn.md) | [第 26 天 >>](./26_python_web_cn.md) 

--- a/Chinese/26_python_web_cn.md
+++ b/Chinese/26_python_web_cn.md
@@ -814,4 +814,4 @@ asabeneh@Asabeneh:~/Desktop/python_for_web$
 
 🎉 恭喜！🎉
 
-[<< 第25天](./25_Day_Pandas/25_pandas_cn.md) | [第27天 >>](./27_Day_Python_with_mongodb/27_python_with_mongodb_cn.md) 
+[<< 第 25 天](./25_pandas_cn.md) | [第 27 天 >>](./27_python_with_mongodb_cn.md) 

--- a/Chinese/27_python_with_mongodb_cn.md
+++ b/Chinese/27_python_with_mongodb_cn.md
@@ -629,4 +629,4 @@ db.students.drop()
 
 🎉 恭喜！🎉
 
-[<< 第26天](./26_Day_Python_web/26_python_web_cn.md) | [第28天 >>](./28_Day_API/28_API_cn.md) 
+[<< 第 26 天](./26_python_web_cn.md) | [第 28 天 >>](./28_API_cn.md) 

--- a/Chinese/28_API_cn.md
+++ b/Chinese/28_API_cn.md
@@ -140,4 +140,4 @@ GET、POST、PUT和DELETE是我们将实现API或CRUD操作应用程序的HTTP�
 
 🎉 恭喜！🎉
 
-[<< 第27天](./27_Day_Python_with_mongodb/27_python_with_mongodb_cn.md) | [第29天 >>](./29_Day_Building_API/29_building_API_cn.md) 
+[<< 第 27 天](./27_python_with_mongodb_cn.md) | [第 29 天 >>](./29_building_API_cn.md) 

--- a/Chinese/29_building_API_cn.md
+++ b/Chinese/29_building_API_cn.md
@@ -457,4 +457,4 @@ if __name__ == '__main__':
 
 🎉 恭喜！🎉
 
-[<< 第28天](./28_Day_API/28_API_cn.md) | [第30天 >>](./30_Day_Conclusions/30_conclusions_cn.md) 
+[<< 第 28 天](./28_API_cn.md) | [第 30 天 >>](./30_conclusions_cn.md) 

--- a/Chinese/30_conclusions_cn.md
+++ b/Chinese/30_conclusions_cn.md
@@ -19,4 +19,4 @@ http://thirtydayofpython-api.herokuapp.com/feedback
 
 🎉 恭喜！🎉
 
-[<< 第29天](./29_Day_Building_API/29_building_API_cn.md) 
+[<< 第 29 天](./29_building_API_cn.md) 

--- a/Chinese/README.md
+++ b/Chinese/README.md
@@ -9,29 +9,29 @@
 | 05     |                            [列表](./05_lists.md)                            |
 | 06     |                           [元组](./06_tuples.md)                           |
 | 07     |                             [集合](./07_sets.md)                             |
-| 08     |                     [字典](./08_Day_Dictionaries/08_dictionaries.md)                     |
-| 09     |                     [条件](./09_Day_Conditionals/09_conditionals.md)                     |
-| 10     |                            [循环](./10_Day_Loops/10_loops.md)                            |
-| 11     |                        [函数](./11_Day_Functions/11_functions.md)                        |
-| 12     |                          [模块](./12_Day_Modules/12_modules.md)                          |
-| 13     |             [列表解析](./13_Day_List_comprehension/13_list_comprehension.md)             |
-| 14     |         [高阶函数](./14_Day_Higher_order_functions/14_higher_order_functions.md)         |
-| 15     |             [类型错误](./15_Day_Python_type_errors/15_python_type_errors.md)             |
-| 16     |            [Python 日期时间](./16_Day_Python_date_time/16_python_datetime.md)            |
-| 17     |             [异常处理](./17_Day_Exception_handling/17_exception_handling.md)             |
-| 18     |           [正则表达式](./18_Day_Regular_expressions/18_regular_expressions.md)           |
-| 19     |                  [文件处理](./19_Day_File_handling/19_file_handling.md)                  |
-| 20     |         [包管理器](./20_Day_Python_package_manager/20_python_package_manager.md)         |
-| 21     |            [类和对象](./21_Day_Classes_and_objects/21_classes_and_objects.md)            |
-| 22     |                   [网页抓取](./22_Day_Web_scraping/22_web_scraping.md)                   |
-| 23     |            [虚拟环境](./23_Day_Virtual_environment/23_virtual_environment.md)            |
-| 24     |                       [统计](./24_Day_Statistics/24_statistics.md)                       |
-| 25     |                          [Pandas](./25_Day_Pandas/25_pandas.md)                          |
-| 26     |                   [Python 网页](./26_Day_Python_web/26_python_web.md)                    |
-| 27     |       [Python 与 MongoDB](./27_Day_Python_with_mongodb/27_python_with_mongodb.md)        |
-| 28     |                              [API](./28_Day_API/28_API.md)                               |
-| 29     |                   [构建 API](./29_Day_Building_API/29_building_API.md)                   |
-| 30     |                      [结论](./30_Day_Conclusions/30_conclusions.md)                      |
+| 08     |                     [字典](./08_dictionaries.md)                     |
+| 09     |                     [条件](./09_conditionals.md)                     |
+| 10     |                            [循环](./10_loops.md)                            |
+| 11     |                        [函数](./11_functions.md)                        |
+| 12     |                          [模块](./12_modules.md)                          |
+| 13     |             [列表解析](./13_list_comprehension.md)             |
+| 14     |         [高阶函数](./14_higher_order_functions.md)         |
+| 15     |             [类型错误](./15_python_type_errors_cn.md)             |
+| 16     |            [Python 日期时间](./16_python_datetime_cn.md)            |
+| 17     |             [异常处理](./17_exception_handling_cn.md)             |
+| 18     |           [正则表达式](./18_regular_expressions_cn.md)           |
+| 19     |                  [文件处理](./19_file_handling_cn.md)                  |
+| 20     |         [包管理器](./20_python_package_manager_cn.md)         |
+| 21     |            [类和对象](./21_classes_and_objects_cn.md)            |
+| 22     |                   [网页抓取](./22_web_scraping_cn.md)                   |
+| 23     |            [虚拟环境](./23_virtual_environment_cn.md)            |
+| 24     |                       [统计](./24_statistics_cn.md)                       |
+| 25     |                          [Pandas](./25_pandas_cn.md)                          |
+| 26     |                   [Python 网页](./26_python_web_cn.md)                    |
+| 27     |       [Python 与 MongoDB](./27_python_with_mongodb_cn.md)        |
+| 28     |                              [API](./28_API_cn.md)                               |
+| 29     |                   [构建 API](./29_building_API_cn.md)                   |
+| 30     |                      [结论](./30_conclusions_cn.md)                      |
 
 🧡🧡🧡 快乐编码 🧡🧡🧡
 
@@ -56,7 +56,7 @@
 
 </div>
 
-[第 2 天 >>](./02_Day_Variables_builtin_functions/02_variables_builtin_functions.md)
+[第 2 天 >>](./02_variables_builtin_functions.md)
 
 ![30DaysOfPython](.././images/30DaysOfPython_banner3@2x.png)
 


### PR DESCRIPTION
## Problem
The Chinese version had broken navigation links after Day 7, making it difficult for users to navigate between chapters.

## What was fixed
- **Day 7-14**: Fixed inconsistent link paths (mixed `../` and `./`)
- **Day 15-30**: Fixed filename inconsistencies (unified `_cn` suffix)
- **Chinese README**: Updated table of contents links
- **Navigation**: Standardized previous/next page link format

## Changes
- Standardized all links to relative path format `./filename.md`
- Fixed 25 Chinese tutorial files (Day 7-30)
- Updated Chinese/README.md table of contents
- All navigation links now work correctly

## Impact
✅ Users can now navigate smoothly between all Chinese tutorial chapters  
✅ Improved learning experience for Chinese-speaking users  
✅ All internal links in Chinese version work properly  

## Testing
All navigation links verified to point to correct files.