### PR TITLE
docs: fix overlapping grade ranges (Day 9)

### DIFF
--- a/09_Day_Conditionals/09_conditionals.md
+++ b/09_Day_Conditionals/09_conditionals.md
@@ -233,13 +233,13 @@ Enter number two: 3
 
    1. Write a code which gives grade to students according to theirs scores:
 
-        ```sh
-        80-100, A
-        70-89, B
-        60-69, C
-        50-59, D
-        0-49, F
-        ```
+    ```sh
+    90-100, A
+    80-89, B
+    70-79, C
+    60-69, D
+    0-59, F
+    ```
 
    1. Check if the season is Autumn, Winter, Spring or Summer. If the user input is:
     September, October or November, the season is Autumn.

--- a/old_files/readme7-9.md
+++ b/old_files/readme7-9.md
@@ -760,11 +760,11 @@ else:
     ```
 1. Write a code which give grade to students according to theirs scores:
     ```sh
-    80-100, A
-    70-89, B
-    60-69, C
-    50-59, D
-    0 -49, F
+    90-100, A
+    80-89, B
+    70-79, C
+    60-69, D
+    0-59, F
     ```
 1. Check if the season is Autumn, Winter, Spring or Summer. If the user input is:
 September, October or November, the season is Autumn.


### PR DESCRIPTION
Fix overlapping and incorrect grade ranges in Day 9 exercise. Make A 90-100, B 80-89, C 70-79, D 60-69, F 0-59. Edits made to  and .