### PR TITLE
typo

### DIFF
--- a/17_Day_Exception_handling/17_exception_handling.md
+++ b/17_Day_Exception_handling/17_exception_handling.md
@@ -270,7 +270,7 @@ for index, item in enumerate([20, 30, 40]):
 for index, i in enumerate(countries):
     print('hi')
     if i == 'Finland':
-        print('The country {i} has been found at index {index}')
+        print(f'The country {i} has been found at index {index}')
 ```
 
 ```sh
@@ -300,6 +300,7 @@ print(fruits_and_veges)
 ## Exercises: Day 17
 
 1. names = ['Finland', 'Sweden', 'Norway','Denmark','Iceland', 'Estonia','Russia']. Unpack the first five countries and store them in a variable nordic_countries, store Estonia and Russia in es, and ru respectively.
+
 
 🎉 CONGRATULATIONS ! 🎉
 


### PR DESCRIPTION
enumerate example was missing the f in the print statement leading it not to actually show the output that the github page shows
for index, i in enumerate(countries):
    print('hi')
    if i == 'Finland':
        print(**f**'The country {i} has been found at index {index}')