### PR TITLE
Fix incorrect data type comment (set vs tuple)

### DIFF
--- a/01_Day_Introduction/helloworld.py
+++ b/01_Day_Introduction/helloworld.py
@@ -22,4 +22,4 @@ print(type(1 + 3j))              # Complex
 print(type('Asabeneh'))          # String
 print(type([1, 2, 3]))           # List
 print(type({'name': 'Asabeneh'}))  # Dictionary
-print(type({9.8, 3.14, 2.7}))    # Tuple
+print(type({9.8, 3.14, 2.7}))    # Set


### PR DESCRIPTION
This PR corrects the comment in the data type checking section.
The last line previously labeled a set as a tuple; it has now been updated to correctly reflect that {9.8, 3.14, 2.7} is a set.

No functional code changes were made — only documentation/comment correction for accuracy.