### PR TITLE
Fix Day 4 question 34 tab escape sequence explanation

### DIFF
--- a/04_Day_Strings/04_strings.md
+++ b/04_Day_Strings/04_strings.md
@@ -578,6 +578,8 @@ print(challenge.startswith('thirty')) # False
     Name      Age     Country   City
     Asabeneh  250     Finland   Helsinki
     ```
+    Note: The exact spacing may vary depending on the terminal or editor because \t moves the cursor to the next tab stop.
+    
 35. Use the string formatting method to display the following:
 
 ```sh


### PR DESCRIPTION
Fixes #762 

**Description about Issue**
The exercise in Day 4 Question 34 shows an expected output with fixed spacing. However, the tab escape sequence (\t) does not guarantee fixed spacing because it moves the cursor to the next tab stop, which can vary depending on the terminal or editor.

**How it helps**
This PR adds a clarification note to the exercise to explain that the **_exact spacing may vary when using \t_.** This helps avoid confusion for learners trying to match the output exactly.

**Screenshot**
<img width="611" height="146" alt="Screenshot 2026-03-12 193826" src="https://github.com/user-attachments/assets/a40c90dc-5a63-4fb8-830f-0f631a582249" />

**Code**
```python
print("Name\tAge\tCountry\tCity")
print("Asabeneh\t250\tFinland\tHelsinki")
```



 
