### PR TITLE
Modified str to int: on old_files/readme.md

### DIFF
--- a/old_files/readme.md
+++ b/old_files/readme.md
@@ -576,8 +576,11 @@ print(num_str)                  # '10'
 
 # str to int
 num_str = '10.6'
-print('num_int', int(num_str))      # 10
-print('num_float', float(num_str))  # 10.6
+num_float = float(num_str)
+num_int = int(num_float)
+
+print('num_int', num_int)     #10
+print('num_float', num_float) #10.6
 
 # str to list
 first = 'Asabeneh'


### PR DESCRIPTION
fixes #792 

**Description what was the issue**
 There was a problem of str to int example Where the str with a decimal number is shown to be directly converted to int without any error, But that was a mistake.

**Screenshot**
<img width="774" height="254" alt="image" src="https://github.com/user-attachments/assets/2e221691-7533-4500-953a-2cda01236740" />

**How I solved**
I converted the str to float datatype first then converting the float to int. so it doesn't cause any error.

**Code**
```python
num_str = '10.6'

num_float = float(num_str)   # Convert the string to float
num_int = int(num_float)     # Convert float to integer

print('num_int', num_int)        # 10
print('num_float', num_float)    # 10.6
```