### PR TITLE
Fix Length mistake on Day4 py file

### DIFF
--- a/04_Day_Strings/day_4.py
+++ b/04_Day_Strings/day_4.py
@@ -30,7 +30,7 @@ print(full_name)  # Asabeneh Yetayeh
 print(len(first_name))  # 8
 print(len(last_name))   # 7
 print(len(first_name) > len(last_name))  # True
-print(len(full_name))  # 15
+print(len(full_name))  # 16
 
 # Unpacking characters
 language = 'Python'
@@ -155,7 +155,8 @@ print(challenge.isalnum())  # False
 # isalpha(): Checks if all characters are alphabets
 
 challenge = 'thirty days of python'
-print(challenge.isalpha())  # True
+print(challenge.isalpha()) #False
+
 num = '123'
 print(num.isalpha())      # False
 


### PR DESCRIPTION
fixes #795 
fixes #797 

**What i did**
1. Making length of full_name variable to be 16 characters, instead of 15.(Issue 795)
2. Changing the challenge.isalpha() to be false.(Issue 797)


**Screenshots**

1st one((Issue 795):
<img width="752" height="172" alt="image" src="https://github.com/user-attachments/assets/ce8ac1cb-3010-43e6-b353-6a6fca8b321b" />

2nd one(Issue 797):
<img width="703" height="197" alt="image" src="https://github.com/user-attachments/assets/0bc856fd-dcde-4fa1-a318-cbfcdcfc9615" />

**Additional Context**
Changes the both issue on same PR.


Thanks.



