### PR TITLE
fix: correct index() examples and section order in Day 4

### DIFF
--- a/04_Day_Strings/04_strings.md
+++ b/04_Day_Strings/04_strings.md
@@ -21,8 +21,8 @@
 - [Day 4](#day-4)
   - [Strings](#strings)
     - [Creating a String](#creating-a-string)
-    - [String Concatenation](#string-concatenation)
     - [Escape Sequences in Strings](#escape-sequences-in-strings)
+    - [String Concatenation](#string-concatenation)
     - [String formatting](#string-formatting)
       - [Old Style String Formatting (% Operator)](#old-style-string-formatting--operator)
       - [New Style String Formatting (str.format)](#new-style-string-formatting-strformat)
@@ -70,23 +70,6 @@ That is why I created 30 days of python."""
 print(multiline_string)
 ```
 
-### String Concatenation
-
-We can connect strings together. Merging or connecting strings is called concatenation. See the example below:
-
-```py
-first_name = 'Asabeneh'
-last_name = 'Yetayeh'
-space = ' '
-full_name = first_name  +  space + last_name
-print(full_name) # Asabeneh Yetayeh
-# Checking the length of a string using len() built-in function
-print(len(first_name))  # 8
-print(len(last_name))   # 7
-print(len(first_name) > len(last_name)) # True
-print(len(full_name)) # 16
-```
-
 ### Escape Sequences in Strings
 
 In Python and other programming languages \ followed by a character is an escape sequence. Let us see the most common escape characters:
@@ -119,6 +102,24 @@ Day 3	5	    23
 Day 4	1	    35
 This is a backslash  symbol (\)
 In every programming language it starts with "Hello, World!"
+```
+
+
+### String Concatenation
+
+We can connect strings together. Merging or connecting strings is called concatenation. See the example below:
+
+```py
+first_name = 'Asabeneh'
+last_name = 'Yetayeh'
+space = ' '
+full_name = first_name  +  space + last_name
+print(full_name) # Asabeneh Yetayeh
+# Checking the length of a string using len() built-in function
+print(len(first_name))  # 8
+print(len(last_name))   # 7
+print(len(first_name) > len(last_name)) # True
+print(len(full_name)) # 16
 ```
 
 ### String formatting

--- a/04_Day_Strings/day_4.py
+++ b/04_Day_Strings/day_4.py
@@ -135,8 +135,8 @@ print(result)  # The area of circle with 10 is 314.0
 
 # index(): Returns the index of substring
 challenge = 'thirty days of python'
-print(challenge.find('y'))  # 5
-print(challenge.find('th'))  # 0
+print(challenge.index('y'))  # 5
+print(challenge.index('th'))  # 0
 
 # isalnum(): Checks alphanumeric character
 


### PR DESCRIPTION
Fixes #796

### Changes made

**day_4.py**
- Fixed the `index()` section (around line 136) which was incorrectly using `.find()` instead of `.index()`
- Fixed the `isdecimal()` section which had leftover `.find()` calls instead of actual `isdecimal()` examples

**04_strings.md**
- Moved the `### Escape Sequences in Strings` section to appear after `#### Unpacking Characters`, so the doc order matches the `.py` file
- Updated the Table of Contents to reflect the new section order

### Why
A beginner following the `.py` file in the terminal and cross-referencing the `.md` doc would see escape sequences before indexing in the doc, but indexing before escape sequences in the code — causing confusion. The `.index()` section was also silently demonstrating `.find()` behavior instead.