### PR TITLE
fix: resolve multiple issues across Day 1, 2, 8, 14, 18, 22

### DIFF
--- a/01_Day_Introduction/helloworld.py
+++ b/01_Day_Introduction/helloworld.py
@@ -22,4 +22,5 @@ print(type(1 + 3j))              # Complex
 print(type('Asabeneh'))          # String
 print(type([1, 2, 3]))           # List
 print(type({'name': 'Asabeneh'}))  # Dictionary
-print(type({9.8, 3.14, 2.7}))    # Tuple
+print(type({9.8, 3.14, 2.7}))    # Set
+print(type((9.8, 3.14, 2.7)))    # Tuple

--- a/02_Day_Variables_builtin_functions/02_variables_builtin_functions.md
+++ b/02_Day_Variables_builtin_functions/02_variables_builtin_functions.md
@@ -231,10 +231,8 @@ print(num_str)                  # '10'
 num_str = '10.6'
 num_float = float(num_str)  # Convert the string to a float first
 num_int = int(num_float)    # Then convert the float to an integer
-print('num_int', int(num_str))      # 10
-print('num_float', float(num_str))  # 10.6
-num_int = int(num_float)
-print('num_int', int(num_int))      # 10
+print('num_int', num_int)      # 10
+print('num_float', num_float)  # 10.6
 
 # str to list
 first_name = 'Asabeneh'

--- a/08_Day_Dictionaries/08_dictionaries.md
+++ b/08_Day_Dictionaries/08_dictionaries.md
@@ -39,7 +39,7 @@
 
 ## Dictionaries
 
-A dictionary is a collection of unordered, modifiable(mutable) paired (key: value) data type.
+A dictionary is a collection of insertion-ordered (since Python 3.7+), modifiable(mutable) paired (key: value) data type.
 
 ### Creating a Dictionary
 
@@ -60,7 +60,7 @@ person = {
     'last_name':'Yetayeh',
     'age':250,
     'country':'Finland',
-    'is_marred':True,
+    'is_married':True,
     'skills':['JavaScript', 'React', 'Node', 'MongoDB', 'Python'],
     'address':{
         'street':'Space street',
@@ -119,7 +119,7 @@ person = {
     'last_name':'Yetayeh',
     'age':250,
     'country':'Finland',
-    'is_marred':True,
+    'is_married':True,
     'skills':['JavaScript', 'React', 'Node', 'MongoDB', 'Python'],
     'address':{
         'street':'Space street',
@@ -141,7 +141,7 @@ person = {
     'last_name':'Yetayeh',
     'age':250,
     'country':'Finland',
-    'is_marred':True,
+    'is_married':True,
     'skills':['JavaScript', 'React', 'Node', 'MongoDB', 'Python'],
     'address':{
         'street':'Space street',
@@ -172,7 +172,7 @@ person = {
     'last_name':'Yetayeh',
     'age':250,
     'country':'Finland',
-    'is_marred':True,
+    'is_married':True,
     'skills':['JavaScript', 'React', 'Node', 'MongoDB', 'Python'],
     'address':{
         'street':'Space street',
@@ -202,7 +202,7 @@ person = {
     'last_name':'Yetayeh',
     'age':250,
     'country':'Finland',
-    'is_marred':True,
+    'is_married':True,
     'skills':['JavaScript', 'React', 'Node', 'MongoDB', 'Python'],
     'address':{
         'street':'Space street',
@@ -247,7 +247,7 @@ person = {
     'last_name':'Yetayeh',
     'age':250,
     'country':'Finland',
-    'is_marred':True,
+    'is_married':True,
     'skills':['JavaScript', 'React', 'Node', 'MongoDB', 'Python'],
     'address':{
         'street':'Space street',

--- a/14_Day_Higher_order_functions/14_higher_order_functions.md
+++ b/14_Day_Higher_order_functions/14_higher_order_functions.md
@@ -349,7 +349,7 @@ numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 1. Use filter to filter out countries having exactly six characters.
 1. Use filter to filter out countries containing six letters and more in the country list.
 1. Use filter to filter out countries starting with an 'E'
-1. Chain two or more list iterators (eg. arr.map(callback).filter(callback).reduce(callback))
+1. Chain two or more list iterators (eg. use map(), filter(), and reduce() together on a list.)
 1. Declare a function called get_string_lists which takes a list as a parameter and then returns a list containing only string items.
 1. Use reduce to sum all the numbers in the numbers list.
 1. Use reduce to concatenate all the countries and to produce this sentence: Estonia, Finland, Sweden, Denmark, Norway, and Iceland are north European countries

--- a/18_Day_Regular_expressions/18_regular_expressions.md
+++ b/18_Day_Regular_expressions/18_regular_expressions.md
@@ -69,7 +69,7 @@ To find a pattern we use different set of *re* character sets that allows to sea
 
 ```py
 # syntax
-re.match(substring, string, re.I)
+re.search(substring, string, re.I)
 # substring is a string or a pattern, string is the text we look for a pattern , re.I is case ignore
 ```
 

--- a/22_Day_Web_scraping/22_web_scraping.md
+++ b/22_Day_Web_scraping/22_web_scraping.md
@@ -99,7 +99,7 @@ For reference check the [beautifulsoup documentation](https://www.crummy.com/sof
 
 ## 💻 Exercises: Day 22
 
-1. Scrape the following website and store the data as json file(url = 'http://www.bu.edu/president/boston-university-facts-stats/').
+1. Scrape the following website and store the data as json file(url = 'https://www.bu.edu/president/boston-university-facts-stats/').
 1. Extract the table in this url (https://archive.ics.uci.edu/ml/datasets.php) and change it to a json file
 2. Scrape the presidents table and store the data as json(https://en.wikipedia.org/wiki/List_of_presidents_of_the_United_States). The table is not very structured and the scrapping may take very long time.
 


### PR DESCRIPTION
Hey! I went through some of the open issues and fixed a bunch of them in one go. Here's what I changed:

---

### #807 + #758 — Day 1: Wrong comment on set/tuple (helloworld.py)
`{9.8, 3.14, 2.7}` is a set, curly braces give you a set not a tuple. The comment said `# Tuple` which is wrong and would confuse beginners. Fixed the comment and also added the actual tuple example with parentheses so both are shown side by side.

---

### #808 — Day 14: That exercise question is JavaScript, not Python
Question 8 in Level 2 had `arr.map(callback).filter(callback).reduce(callback)` — that's JS method chaining. Python doesn't work like that, map/filter/reduce are standalone functions. I have replaced it with a proper Python description.

---

### #775 + #792 — Day 2: `int('10.6')` crashes with ValueError
The example tried to do `int(num_str)` directly on `'10.6'` which just throws a ValueError. Also had the same variable assigned twice for no reason and `int(num_int)` on something that was already an int. Cleaned the whole thing up.

---

### #760 — Day 22: Broken URL in exercise
The BU facts page link was using `http://` and returning a 404. Just changed it to `https://`, the page is still up.

---

### #749 — Day 18: `re.match` in the search syntax example
The syntax section for `re.search` was showing `re.match(...)` instead. Simple!

---

### #731 — Day 8: Dictionaries are not "unordered" anymore
Calling dicts unordered is only true for Python 3.6 and below. Since 3.7 they maintain insertion order. Updated the definition to reflect that — also avoided just saying "ordered" since that implies sorting which isn't the case.

---

### #721 — Day 8: `is_marred` typo
The person dictionary had `is_marred` instead of `is_married` in 6 different places, which also broke some of the code examples further down. I have fixed all of them.