### PR TITLE
Fix ages list for statistics examples

### DIFF
--- a/12_Day_Modules/12_modules.md
+++ b/12_Day_Modules/12_modules.md
@@ -163,7 +163,7 @@ The statistics module provides functions for mathematical statistics of numeric 
 
 ```py
 from statistics import * # importing all the statistics modules
-ages = [20, 20, 4, 24, 25, 22, 26, 20, 23, 22, 26]
+ages = [20, 20, 24, 24, 25, 22, 26, 20, 23, 22, 26]
 print(mean(ages))       # ~22.9
 print(median(ages))     # 23
 print(mode(ages))       # 20


### PR DESCRIPTION
in commit:
https://github.com/Asabeneh/30-Days-Of-Python/commit/3b7d61657cee6420f5c5fae7d6498aa79bf2d02b#diff-081ab49013cc1db7ed5a7b8ae89e904b23b0ad6304d648d223e47ab8e23e2e19L165

the `ages` list was changed (24 → 4), so the expected results (~22.9, 23, 20, and ~2.3) no longer match.