### PR TITLE
Fix explanation of 'pass' statement and update list comprehension/even numbers examples

### DIFF
--- a/10_Day_Loops/10_loops.md
+++ b/10_Day_Loops/10_loops.md
@@ -375,7 +375,7 @@ else:
 
 ### Pass
 
-In python when statement is required (after semicolon), but we don't like to execute any code there, we can write the word _pass_ to avoid errors. Also we can use it as a placeholder, for future statements.
+In python when statement is required (after a colon), but we don't like to execute any code there, we can write the word _pass_ to avoid errors. Also we can use it as a placeholder, for future statements.
 
 **Example:**
 

--- a/13_Day_List_comprehension/13_list_comprehension.md
+++ b/13_Day_List_comprehension/13_list_comprehension.md
@@ -70,7 +70,7 @@ print(squares)                    # [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
 
 # It is also possible to make a list of tuples
 numbers = [(i, i * i) for i in range(11)]
-print(numbers)                             # [(0, 0), (1, 1), (2, 4), (3, 9), (4, 16), (5, 25)]
+print(numbers)                             # [(0, 0), (1, 1), (2, 4), (3, 9), (4, 16), (5, 25), (6, 36), (7, 49), (8, 64), (9, 81), (10, 100)]]
 
 ```
 

--- a/13_Day_List_comprehension/13_list_comprehension.md
+++ b/13_Day_List_comprehension/13_list_comprehension.md
@@ -90,7 +90,7 @@ print(odd_numbers)                      # [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
 # Filter numbers: let's filter out positive even numbers from the list below
 numbers = [-8, -7, -3, -1, 0, 1, 3, 4, 5, 7, 6, 8, 10]
 positive_even_numbers = [i for i in numbers if i % 2 == 0 and i > 0]
-print(positive_even_numbers)                    # [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+print(positive_even_numbers)                    #[4, 6, 8, 10]
 
 # Flattening a two dimensional array
 list_of_lists = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]


### PR DESCRIPTION
I noticed a small mistake on line 378 under the "Pass" section.

Corrected the wording from 'after semicolon' to 'after a colon' for clarity. as it may cause confusion to beginners. 
as colon is used here .
please acknowledge this small change.