### PR TITLE
fix: correct comment typo in Day 3 example

### DIFF
--- a/03_Day_Operators/day-3.py
+++ b/03_Day_Operators/day-3.py
@@ -25,7 +25,7 @@ print('Multiplying complex number: ', (1+1j) * (1-1j))
 # Declaring the variable at the top first
 
 a = 3  # a is a variable name and 3 is an integer data type
-b = 2  # b is a variable name and 3 is an integer data type
+b = 2  # b is a variable name and 2 is an integer data type
 
 # Arithmetic operations and assigning the result to a variable
 total = a + b


### PR DESCRIPTION
In `03_Day_Operators/day-3.py`, the comment says '3' but variable `b` is assigned 2.

Closes #850