### PR TITLE
Fix broken Gutenberg and Rest Countries API URLs

### DIFF
--- a/20_Day_Python_package_manager/20_python_package_manager.md
+++ b/20_Day_Python_package_manager/20_python_package_manager.md
@@ -259,11 +259,11 @@ print(response.text) # gives all the text from the page
 {'date': 'Sun, 08 Dec 2019 18:00:31 GMT', 'last-modified': 'Fri, 07 Nov 2003 05:51:11 GMT', 'etag': '"17e9-3cb82080711c0;50c0b26855880-gzip"', 'accept-ranges': 'bytes', 'cache-control': 'max-age=31536000', 'expires': 'Mon, 07 Dec 2020 18:00:31 GMT', 'vary': 'Accept-Encoding', 'content-encoding': 'gzip', 'access-control-allow-origin': '*', 'content-length': '1616', 'content-type': 'text/plain', 'strict-transport-security': 'max-age=15552000; includeSubdomains; preload', 'content-security-policy': 'upgrade-insecure-requests'}
 ```
 
-- Let us read from an API. API stands for Application Program Interface. It is a means to exchange structure data between servers primarily a json data. An example of an API:https://restcountries.eu/rest/v2/all. Let us read this API using _requests_ module.
+- Let us read from an API. API stands for Application Program Interface. It is a means to exchange structure data between servers primarily a json data. An example of an API:https://restcountries.com/v3.1/all?fields=name,capital,currencies. Let us read this API using _requests_ module.
 
 ```py
 import requests
-url = 'https://restcountries.eu/rest/v2/all'  # countries api
+url = 'https://restcountries.com/v3.1/all?fields=name,capital,currencies'  # countries api
 response = requests.get(url)  # opening a network and fetching a data
 print(response) # response object
 print(response.status_code)  # status code, success:200
@@ -443,12 +443,12 @@ The **__init__**.py exposes specified resources from its modules to be imported 
 
 ## Exercises: Day 20
 
-1. Read this url and find the 10 most frequent words. romeo_and_juliet = 'http://www.gutenberg.org/files/1112/1112.txt'
+1. Read this url and find the 10 most frequent words. romeo_and_juliet = 'https://www.gutenberg.org/cache/epub/1513/pg1513.txt'
 2. Read the cats API and cats_api = 'https://api.thecatapi.com/v1/breeds' and find :
    1. the min, max, mean, median, standard deviation of cats' weight in metric units.
    2. the min, max, mean, median, standard deviation of cats' lifespan in years.
    3. Create a frequency table of country and breed of cats
-3. Read the [countries API](https://restcountries.eu/rest/v2/all) and find
+3. Read the [countries API](https://restcountries.com/v3.1/all?fields=name,capital,currencies) and find
    1. the 10 largest countries
    2. the 10 most spoken languages
    3. the total number of languages in the countries API

--- a/28_Day_API/28_API.md
+++ b/28_Day_API/28_API.md
@@ -51,7 +51,7 @@ Using API, content that is created in one place dynamically can be posted and up
 
 For example, Twitter's REST API allows developers to access core Twitter data and the Search API provides methods for developers to interact with Twitter Search and trends data.
 
-Many applications provide API end points. Some  examples of API such as the countries [API](https://restcountries.eu/rest/v2/all), [cat's breed API](https://api.thecatapi.com/v1/breeds).
+Many applications provide API end points. Some  examples of API such as the countries [API](https://restcountries.com/v3.1/all?fields=name,capital,currencies), [cat's breed API](https://api.thecatapi.com/v1/breeds).
 
 In this section, we will cover a RESTful API that uses HTTP request methods to GET, PUT, POST and DELETE data.
 

--- a/my_notes/day01_notes.md
+++ b/my_notes/day01_notes.md
@@ -1,0 +1,28 @@
+\# Day 1 - Python Basics
+
+
+
+\## Topics Learned
+
+\- Variables
+
+\- Data Types
+
+\- Strings
+
+
+
+\## Practice
+
+
+
+x = 10
+
+name = "Girish"
+
+
+
+print(x)
+
+print(name)
+

--- a/readme.md
+++ b/readme.md
@@ -523,3 +523,7 @@ To run the python file check the image below. You can run the python file either
 🎉 CONGRATULATIONS ! 🎉
 
 [Day 2 >>](./02_Day_Variables_builtin_functions/02_variables_builtin_functions.md)
+
+## Additional Resources
+
+- Python Official Documentation: https://docs.python.org/3/


### PR DESCRIPTION
Fixes #825

Updated outdated URLs in the Day 20 and Day 28 materials.

Changes:

* Replaced the broken Project Gutenberg Romeo and Juliet URL with a working URL.
* Updated Rest Countries API URLs to the current endpoint.

These changes resolve 404 errors encountered while following the exercises.
