### PR TITLE
Fix typo in set intersection example (thia → this)

### DIFF
--- a/07_Day_Sets/07_sets.md
+++ b/07_Day_Sets/07_sets.md
@@ -275,7 +275,7 @@ Intersection returns a set of items which are in both the sets or using _&_ symb
 st1 = {'item1', 'item2', 'item3', 'item4'}
 st2 = {'item3', 'item2'}
 st1.intersection(st2) # {'item3', 'item2'}
-# or using thia : st1 & st2
+# or using this : st1 & st2
 ```
 
 **Example:**


### PR DESCRIPTION
Fixes a typo in the “Finding Intersection Items” section of 07_Day_Sets/07_sets.md  (thia → this). 

Related issue: #864.