### PR TITLE
Fix Day 17 range example output and spacing

### DIFF
--- a/17_Day_Exception_handling/17_exception_handling.md
+++ b/17_Day_Exception_handling/17_exception_handling.md
@@ -179,7 +179,7 @@ numbers = range(2, 7)  # normal call with separate arguments
 print(list(numbers)) # [2, 3, 4, 5, 6]
 args = [2, 7]
 numbers = range(*args)  # call with arguments unpacked from a list
-print(numbers)      # [2, 3, 4, 5,6]
+print(list(numbers))      # [2, 3, 4, 5, 6]
 
 ```
 


### PR DESCRIPTION
Changes print(numbers) to print(list(numbers)) so the example output matches the expected list. 
Related issue: #759 .

also corrects spacing in comments
Related issue: #813 .