### PR TITLE
Fix Day 13 filter example to use numbers list

### DIFF
--- a/13_Day_List_comprehension/13_list_comprehension.md
+++ b/13_Day_List_comprehension/13_list_comprehension.md
@@ -87,10 +87,11 @@ print(even_numbers)                    # [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
 # Generating odd numbers
 odd_numbers = [i for i in range(21) if i % 2 != 0]  # to generate odd numbers in range 0 to 21
 print(odd_numbers)                      # [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+
 # Filter numbers: let's filter out positive even numbers from the list below
 numbers = [-8, -7, -3, -1, 0, 1, 3, 4, 5, 7, 6, 8, 10]
 positive_even_numbers = [i for i in numbers if i % 2 == 0 and i > 0]
-print(positive_even_numbers)                    # [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+print(positive_even_numbers)                    # [4, 6, 8, 10,]
 
 # Flattening a two dimensional array
 list_of_lists = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]


### PR DESCRIPTION
Updates the “Filter numbers” example to filter the numbers list instead of using range(21).
also add a 'blank newline'

Related issue: #553.