### PR TITLE
Fix ValueError in Day 2 string-to-int casting example

### DIFF
--- a/02_Day_Variables_builtin_functions/02_variables_builtin_functions.md
+++ b/02_Day_Variables_builtin_functions/02_variables_builtin_functions.md
@@ -231,8 +231,9 @@ print(num_str)                  # '10'
 num_str = '10.6'
 num_float = float(num_str)  # Convert the string to a float first
 num_int = int(num_float)    # Then convert the float to an integer
-print('num_int', int(num_str))      # 10
+print('num_int', int(float(num_str)))      # 10
 print('num_float', float(num_str))  # 10.6
+
 num_int = int(num_float)
 print('num_int', int(num_int))      # 10
 


### PR DESCRIPTION
### Description
Fixes a `ValueError: invalid literal for int() with base 10: '10.6'` in the Day 2 data type casting examples. In Python, a string containing a float literal cannot be directly cast to an integer using `int()`. It must first be parsed as a float.

### Changes Made
* Updated `int(num_str)` to `int(float(num_str))` where `num_str = '10.6'`.

### Verification
* Confirmed the script now executes smoothly without throwing a runtime error.

Closes #547