### PR TITLE
Fix duplicate 25&27 and 23&26 questions in Day 4 strings exercises

### DIFF
--- a/04_Day_Strings/04_strings.md
+++ b/04_Day_Strings/04_strings.md
@@ -558,27 +558,26 @@ print(challenge.startswith('thirty')) # False
 22. Use rfind to determine the position of the last occurrence of l in Coding For All People.
 23. Use index or find to find the position of the first occurrence of the word 'because' in the following sentence: 'You cannot end a sentence with because because because is a conjunction'
 24. Use rindex to find the position of the last occurrence of the word because in the following sentence: 'You cannot end a sentence with because because because is a conjunction'
-25. Slice out the phrase 'because because because' in the following sentence: 'You cannot end a sentence with because because because is a conjunction'
-26. Find the position of the first occurrence of the word 'because' in the following sentence: 'You cannot end a sentence with because because because is a conjunction'
-27. Slice out the phrase 'because because because' in the following sentence: 'You cannot end a sentence with because because because is a conjunction'
-28. Does 'Coding For All' start with a substring _Coding_?
-29. Does 'Coding For All' end with a substring _coding_?
-30. '&nbsp;&nbsp; Coding For All &nbsp;&nbsp;&nbsp; &nbsp;' &nbsp;, remove the left and right trailing spaces in the given string.
-31. Which one of the following variables return True when we use the method isidentifier():
+25. Slice out the phrase 'because because because' in the following sentence: 'You cannot end a sentence with because because because is a conjunction' 
+26. Does 'Coding For All' start with a substring _Coding_? 
+27. Does 'Coding For All' end with a substring _coding_?
+28. '&nbsp;&nbsp; Coding For All &nbsp;&nbsp;&nbsp; &nbsp;' &nbsp;, remove the left and right trailing spaces in the given string. 
+29. Which one of the following variables return True when we use the method isidentifier():
     - 30DaysOfPython
     - thirty_days_of_python
-32. The following list contains the names of some of python libraries: ['Django', 'Flask', 'Bottle', 'Pyramid', 'Falcon']. Join the list with a hash with space string.
-33. Use the new line escape sequence to separate the following sentences.
+30. The following list contains the names of some of python libraries: ['Django', 'Flask', 'Bottle', 'Pyramid', 'Falcon']. Join the list with a hash with space string. 
+31. Use the new line escape sequence to separate the following sentences. 
     ```py
     I am enjoying this challenge.
     I just wonder what is next.
     ```
-34. Use a tab escape sequence to write the following lines.
-    ```py
+32. Use a tab escape sequence to write the following lines. 
+    
+33. ```py
     Name      Age     Country   City
     Asabeneh  250     Finland   Helsinki
     ```
-35. Use the string formatting method to display the following:
+34. Use the string formatting method to display the following:
 
 ```sh
 radius = 10
@@ -586,7 +585,7 @@ area = 3.14 * radius ** 2
 The area of a circle with radius 10 is 314 meters square.
 ```
 
-36. Make the following using string formatting methods:
+35. Make the following using string formatting methods:
 
 ```sh
 8 + 6 = 14


### PR DESCRIPTION
### Description
Resolves a confusion point in the Day 4 Strings material where exercise questions #25 & #27 and #23 & #26 were completely identical duplicates.

### Changes Made
* Removed the duplicate exercise statement.
* Corrected the sequential list numbering for the remaining exercises below it.

### Verification
* Verified markdown rendering layout to ensure formatting and numbers flow cleanly.

Closes #863