### PR TITLE
Fix broken UCI dataset link in Day 22 Web Scraping

### DIFF
--- a/22_Day_Web_scraping/22_web_scraping.md
+++ b/22_Day_Web_scraping/22_web_scraping.md
@@ -100,7 +100,7 @@ For reference check the [beautifulsoup documentation](https://www.crummy.com/sof
 ## 💻 Exercises: Day 22
 
 1. Scrape the following website and store the data as json file(url = 'http://www.bu.edu/president/boston-university-facts-stats/').
-1. Extract the table in this url (https://archive.ics.uci.edu/ml/datasets.php) and change it to a json file
+1. Extract the table in this url (https://archive.ics.uci.edu/datasets) and change it to a json file
 2. Scrape the presidents table and store the data as json(https://en.wikipedia.org/wiki/List_of_presidents_of_the_United_States). The table is not very structured and the scrapping may take very long time.
 
 🎉 CONGRATULATIONS ! 🎉


### PR DESCRIPTION
### Description
Fixes a broken 404 URL in the Day 22 Web Scraping documentation and code examples caused by the UCI Machine Learning Repository migrating away from their legacy `.php` directory structure.

### Changes Made
* Updated `https://archive.ics.uci.edu/ml/datasets.php` to the modern active URL: `https://archive.ics.uci.edu/datasets`.

### Verification
* Verified that the new URL returns a successful `200 OK` status code and resolves to the active dataset catalog for scraping.

Closes #825