### PR TITLE
Fix in Day 6 duplicate 'Negative indexing' heading repetition 

### DIFF
--- a/06_Day_Tuples/06_tuples.md
+++ b/06_Day_Tuples/06_tuples.md
@@ -96,8 +96,9 @@ len(tpl)
   last_fruit = fruits[last_index]
   ```
 
-- Negative indexing
-  Negative indexing means beginning from the end, -1 refers to the last item, -2 refers to the second last and the negative of the list/tuple length refers to the first item.
+- Negative indexing 
+  means beginning from the end, -1 refers to the last item, -2 refers to the second last and the negative of the list/tuple length refers to the first item.
+  
   ![Tuple Negative indexing](../images/tuple_negative_indexing.png)
 
   ```py


### PR DESCRIPTION
### Description
Resolves a minor documentation bug in `06_tuples.md` where the heading or bullet list mapping for 'Negative indexing' was accidentally declared twice consecutively.

### Changes Made
* Removed the redundant duplicate 'Negative indexing' block reference to clean up the content hierarchy flow.

Closes #858