### PR TITLE
Update examples to use 'JavaScript' instead of 'python'

### DIFF
--- a/18_Day_Regular_expressions/18_regular_expressions.md
+++ b/18_Day_Regular_expressions/18_regular_expressions.md
@@ -179,10 +179,10 @@ txt = '''Python is the most beautiful language that a human being has ever creat
 I recommend python for a first programming language'''
 
 match_replaced = re.sub('Python|python', 'JavaScript', txt, re.I)
-print(match_replaced)  # JavaScript is the most beautiful language that a human being has ever created.I recommend python for a first programming language
+print(match_replaced)  # JavaScript is the most beautiful language that a human being has ever created.I recommend JavaScript for a first programming language
 # OR
 match_replaced = re.sub('[Pp]ython', 'JavaScript', txt, re.I)
-print(match_replaced)  # JavaScript is the most beautiful language that a human being has ever created.I recommend python for a first programming language
+print(match_replaced)  # JavaScript is the most beautiful language that a human being has ever created.I recommend JavaScript for a first programming language
 ```
 
 Let us add one more example. The following string is really hard to read unless we remove the % symbol. Replacing the % with an empty string will clean the text.


### PR DESCRIPTION
Updated print statements to replace 'python' with 'JavaScript' for consistency in examples.