### PR TITLE
docs: fix function name typo in Day 11

### DIFF
--- a/11_Day_Functions/11_functions.md
+++ b/11_Day_Functions/11_functions.md
@@ -422,7 +422,7 @@ Now it is time to express your thoughts about the Author and 30DaysOfPython. You
 1. Declare a function _add_two_numbers_. It takes two parameters and it returns a sum.
 2. Area of a circle is calculated as follows: area = π x r x r. Write a function that calculates _area_of_circle_.
 3. Write a function called add_all_nums which takes arbitrary number of arguments and sums all the arguments. Check if all the list items are number types. If not do give a reasonable feedback.
-4. Temperature in °C can be converted to °F using this formula: °F = (°C x 9/5) + 32. Write a function which converts °C to °F, _convert_celsius_to-fahrenheit_.
+4. Temperature in °C can be converted to °F using this formula: °F = (°C x 9/5) + 32. Write a function which converts °C to °F, _convert_celsius_to_fahrenheit_.
 5. Write a function called check-season, it takes a month parameter and returns the season: Autumn, Winter, Spring or Summer.
 6. Write a function called calculate_slope which return the slope of a linear equation
 7. Quadratic equation is calculated as follows: ax² + bx + c = 0. Write a function which calculates solution set of a quadratic equation, _solve_quadratic_eqn_.


### PR DESCRIPTION
## Summary

This PR fixes a typo in the Day 11 function name.

### Changes
- Renamed `convert_celsius_to-fahrenheit` to `convert_celsius_to_fahrenheit` in `11_Day_Functions/11_functions.md`.

Fixes #903