### PR TITLE
Fix incorrect comment for set type and add comment for tuple type in …

### DIFF
--- a/01_Day_Introduction/helloworld.py
+++ b/01_Day_Introduction/helloworld.py
@@ -22,4 +22,5 @@ print(type(1 + 3j))              # Complex
 print(type('Asabeneh'))          # String
 print(type([1, 2, 3]))           # List
 print(type({'name': 'Asabeneh'}))  # Dictionary
-print(type({9.8, 3.14, 2.7}))    # Tuple
+print(type((9.8, 3.14, 2.7)))    # Tuple
+print(type({9.8, 3.14, 2.7}))    # Set


### PR DESCRIPTION
…helloworld.py

The line `print(type({9.8, 3.14, 2.7}))` uses curly braces,  which creates a `set`, not a `tuple`. The original comment  `# Tuple` was misleading.

This PR adds a separate example using round brackets `()` to  correctly demonstrate a tuple, and fixes the comment for the  set example to say `# Set` instead.