### PR TITLE
Fix incorrect string to int conversion example

### DIFF
--- a/02_Day_Variables_builtin_functions/02_variables_builtin_functions.md
+++ b/02_Day_Variables_builtin_functions/02_variables_builtin_functions.md
@@ -231,7 +231,7 @@ print(num_str)                  # '10'
 num_str = '10.6'
 num_float = float(num_str)  # Convert the string to a float first
 num_int = int(num_float)    # Then convert the float to an integer
-print('num_int', int(num_str))      # 10
+print('num_int', int(num_float))      # 10
 print('num_float', float(num_str))  # 10.6
 num_int = int(num_float)
 print('num_int', int(num_int))      # 10


### PR DESCRIPTION
The example attempts to convert the string `"10.6"` directly using `int(num_str)`, which raises a `ValueError`.

This PR updates the example to use the already converted integer value so the code executes successfully and matches the explanation.