### PR TITLE
Fix duplicate/mislabeled `isdecimal()` section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ numpy.ipynb
 .vscode/
 *~
 test.py
+venv/

--- a/01_Day_Introduction/helloworld.ipynb
+++ b/01_Day_Introduction/helloworld.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1078d90e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello World!\n",
+      "5\n",
+      "2\n",
+      "6\n",
+      "5\n",
+      "1\n",
+      "6\n",
+      "1.5\n",
+      "9\n",
+      "1\n",
+      "1\n",
+      "<class 'int'>\n",
+      "<class 'float'>\n",
+      "<class 'complex'>\n",
+      "<class 'str'>\n",
+      "<class 'list'>\n",
+      "<class 'dict'>\n",
+      "<class 'set'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Introduction\n",
+    "# Day 1 - 30DaysOfPython Challenge\n",
+    "\n",
+    "print(\"Hello World!\")   # print hello world\n",
+    "\n",
+    "print(2 + 3)   # addition(+)\n",
+    "print(3 - 1)   # subtraction(-)\n",
+    "print(2 * 3)   # multiplication(*)\n",
+    "print(3 + 2)   # addition(+)\n",
+    "print(3 - 2)   # subtraction(-)\n",
+    "print(3 * 2)   # multiplication(*)\n",
+    "print(3 / 2)   # division(/)\n",
+    "print(3 ** 2)  # exponential(**)\n",
+    "print(3 % 2)   # modulus(%)\n",
+    "print(3 // 2)  # Floor division operator(//)\n",
+    "\n",
+    "# Checking data types\n",
+    "\n",
+    "print(type(10))                  # Int\n",
+    "print(type(3.14))                # Float\n",
+    "print(type(1 + 3j))              # Complex\n",
+    "print(type('Asabeneh'))          # String\n",
+    "print(type([1, 2, 3]))           # List\n",
+    "print(type({'name': 'Asabeneh'}))  # Dictionary\n",
+    "print(type({9.8, 3.14, 2.7}))    # Tuple"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.11.15)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/02_Day_Variables_builtin_functions/variables.ipynb
+++ b/02_Day_Variables_builtin_functions/variables.ipynb
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afc3895e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Variables in Python\n",
+    "\n",
+    "first_name = 'Asabeneh'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a285f551",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First name: Asabeneh\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Printing the values stored in the variables\n",
+    "\n",
+    "print('First name:', first_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bf9c0e29",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First name: Asabeneh\n",
+      "Last name:  Yetayeh\n",
+      "Last name length:  7\n",
+      "Country:  Finland\n",
+      "City:  Helsinki\n",
+      "Age:  250\n",
+      "Married:  True\n",
+      "Skills:  ['HTML', 'CSS', 'JS', 'React', 'Python']\n",
+      "Person information:  {'firstname': 'Asabeneh', 'lastname': 'Yetayeh', 'country': 'Finland', 'city': 'Helsinki'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# Variables in Python\n",
+    "\n",
+    "first_name = 'Asabeneh'\n",
+    "last_name = 'Yetayeh'\n",
+    "country = 'Finland'\n",
+    "city = 'Helsinki'\n",
+    "age = 250\n",
+    "is_married = True\n",
+    "skills = ['HTML', 'CSS', 'JS', 'React', 'Python']\n",
+    "person_info = {\n",
+    "    'firstname': 'Asabeneh',\n",
+    "    'lastname': 'Yetayeh',\n",
+    "    'country': 'Finland',\n",
+    "    'city': 'Helsinki'\n",
+    "}\n",
+    "\n",
+    "# Printing the values stored in the variables\n",
+    "\n",
+    "print('First name:', first_name)\n",
+    "print('Last name: ', last_name)\n",
+    "print('Last name length: ', len(last_name))\n",
+    "print('Country: ', country)\n",
+    "print('City: ', city)\n",
+    "print('Age: ', age)\n",
+    "print('Married: ', is_married)\n",
+    "print('Skills: ', skills)\n",
+    "print('Person information: ', person_info)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d1227ab8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Asabeneh Yetayeh Helsink 250 True\n",
+      "First name: Asabeneh\n",
+      "Last name:  Yetayeh\n",
+      "Country:  Helsink\n",
+      "Age:  250\n",
+      "Married:  True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Declaring multiple variables in one line\n",
+    "\n",
+    "first_name, last_name, country, age, is_married = 'Asabeneh', 'Yetayeh', 'Helsink', 250, True\n",
+    "\n",
+    "print(first_name, last_name, country, age, is_married)\n",
+    "print('First name:', first_name)\n",
+    "print('Last name: ', last_name)\n",
+    "print('Country: ', country)\n",
+    "print('Age: ', age)\n",
+    "print('Married: ', is_married)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.11.15)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/02_Day_Variables_builtin_functions/variables.py
+++ b/02_Day_Variables_builtin_functions/variables.py
@@ -1,4 +1,3 @@
-
 # Variables in Python
 
 first_name = 'Asabeneh'

--- a/03_Day_Operators/day-3.ipynb
+++ b/03_Day_Operators/day-3.ipynb
@@ -1,0 +1,359 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e4ebdf7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Addition:  3\n",
+      "Subtraction:  1\n",
+      "Multiplication:  6\n",
+      "Division:  2.0\n",
+      "Division:  3.0\n",
+      "Division:  3.5\n",
+      "Division without the remainder:  3\n",
+      "Modulus:  1\n",
+      "Division without the remainder:  2\n",
+      "Exponential:  9\n",
+      "Floating Number,PI 3.14\n",
+      "Floating Number, gravity 9.81\n",
+      "Complex number:  (1+1j)\n",
+      "Multiplying complex number:  (2+0j)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Arithmetic Operations in Python\n",
+    "# Integers\n",
+    "\n",
+    "print('Addition: ', 1 + 2)\n",
+    "print('Subtraction: ', 2 - 1)\n",
+    "print('Multiplication: ', 2 * 3)\n",
+    "# Division in python gives floating number\n",
+    "print('Division: ', 4 / 2)\n",
+    "print('Division: ', 6 / 2)\n",
+    "print('Division: ', 7 / 2)\n",
+    "# gives without the floating number or without the remaining\n",
+    "print('Division without the remainder: ', 7 // 2)\n",
+    "print('Modulus: ', 3 % 2)                           # Gives the remainder\n",
+    "print('Division without the remainder: ', 7 // 3)\n",
+    "print('Exponential: ', 3 ** 2)                     # it means 3 * 3\n",
+    "\n",
+    "# Floating numbers\n",
+    "print('Floating Number,PI', 3.14)\n",
+    "print('Floating Number, gravity', 9.81)\n",
+    "\n",
+    "# Complex numbers\n",
+    "print('Complex number: ', 1+1j)\n",
+    "print('Multiplying complex number: ', (1+1j) * (1-1j))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dc30597c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n",
+      "a + b =  5\n",
+      "a - b =  1\n",
+      "a * b =  6\n",
+      "a / b =  1.5\n",
+      "a % b =  1\n",
+      "a // b =  1\n",
+      "a ** b =  9\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Declaring the variable at the top first\n",
+    "\n",
+    "a = 3  # a is a variable name and 3 is an integer data type\n",
+    "b = 2  # b is a variable name and 3 is an integer data type\n",
+    "\n",
+    "# Arithmetic operations and assigning the result to a variable\n",
+    "total = a + b\n",
+    "diff = a - b\n",
+    "product = a * b\n",
+    "division = a / b\n",
+    "remainder = a % b\n",
+    "floor_division = a // b\n",
+    "exponential = a ** b\n",
+    "\n",
+    "# I should have used sum instead of total but sum is a built-in function try to avoid overriding builtin functions\n",
+    "print(total)  # if you don't label your print with some string, you never know from where is  the result is coming\n",
+    "print('a + b = ', total)\n",
+    "print('a - b = ', diff)\n",
+    "print('a * b = ', product)\n",
+    "print('a / b = ', division)\n",
+    "print('a % b = ', remainder)\n",
+    "print('a // b = ', floor_division)\n",
+    "print('a ** b = ', exponential)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "97e96d11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total:  7\n",
+      "difference:  1\n",
+      "product:  12\n",
+      "division:  1.0\n",
+      "remainder:  1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Declaring values and organizing them together\n",
+    "num_one = 3\n",
+    "num_two = 4\n",
+    "\n",
+    "# Arithmetic operations\n",
+    "total = num_one + num_two\n",
+    "diff = num_two - num_one\n",
+    "product = num_one * num_two\n",
+    "div = num_two / num_two\n",
+    "remainder = num_two % num_one\n",
+    "\n",
+    "# Printing values with label\n",
+    "print('total: ', total)\n",
+    "print('difference: ', diff)\n",
+    "print('product: ', product)\n",
+    "print('division: ', div)\n",
+    "print('remainder: ', remainder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8952bc03",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Area of a circle: 314.0\n",
+      "Area of rectangle: 200\n",
+      "735.75 N\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Calculating area of a circle\n",
+    "radius = 10                                 # radius of a circle\n",
+    "# two * sign means exponent or power\n",
+    "area_of_circle = 3.14 * radius ** 2\n",
+    "print('Area of a circle:', area_of_circle)\n",
+    "\n",
+    "# Calculating area of a rectangle\n",
+    "length = 10\n",
+    "width = 20\n",
+    "area_of_rectangle = length * width\n",
+    "print('Area of rectangle:', area_of_rectangle)\n",
+    "\n",
+    "# Calculating a weight of an object\n",
+    "mass = 75\n",
+    "gravity = 9.81\n",
+    "weight = mass * gravity\n",
+    "print(weight, 'N')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a794cd8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "True\n",
+      "False\n",
+      "True\n",
+      "True\n",
+      "False\n",
+      "True\n",
+      "False\n",
+      "True\n",
+      "True\n",
+      "False\n",
+      "True\n",
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(3 > 2)     # True, because 3 is greater than 2\n",
+    "print(3 >= 2)    # True, because 3 is greater than 2\n",
+    "print(3 < 2)     # False,  because 3 is greater than 2\n",
+    "print(2 < 3)     # True, because 2 is less than 3\n",
+    "print(2 <= 3)    # True, because 2 is less than 3\n",
+    "print(3 == 2)    # False, because 3 is not equal to 2\n",
+    "print(3 != 2)    # True, because 3 is not equal to 2\n",
+    "print(len('mango') == len('avocado'))  # False\n",
+    "print(len('mango') != len('avocado'))  # True\n",
+    "print(len('mango') < len('avocado'))   # True\n",
+    "print(len('milk') != len('meat'))      # False\n",
+    "print(len('milk') == len('meat'))      # True\n",
+    "print(len('tomato') == len('potato'))  # True\n",
+    "print(len('python') > len('dragon'))   # False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e8aacac8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True == True:  True\n",
+      "True == False:  False\n",
+      "False == False: True\n",
+      "True and True:  True\n",
+      "True or False: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Boolean comparison\n",
+    "print('True == True: ', True == True)\n",
+    "print('True == False: ', True == False)\n",
+    "print('False == False:', False == False)\n",
+    "print('True and True: ', True and True)\n",
+    "print('True or False:', True or False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fe32d0a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 is 1 True\n",
+      "1 is not 2 True\n",
+      "A in Asabeneh True\n",
+      "B in Asabeneh False\n",
+      "True\n",
+      "a in an: True\n",
+      "4 is 2 ** 2: True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<>:3: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "<>:4: SyntaxWarning: \"is not\" with a literal. Did you mean \"!=\"?\n",
+      "<>:10: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "<>:3: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "<>:4: SyntaxWarning: \"is not\" with a literal. Did you mean \"!=\"?\n",
+      "<>:10: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "C:\\Users\\bravefe999\\AppData\\Local\\Temp\\ipykernel_2916\\2940091877.py:3: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "  print('1 is 1', 1 is 1)\n",
+      "C:\\Users\\bravefe999\\AppData\\Local\\Temp\\ipykernel_2916\\2940091877.py:4: SyntaxWarning: \"is not\" with a literal. Did you mean \"!=\"?\n",
+      "  print('1 is not 2', 1 is not 2)           # True - because 1 is not 2\n",
+      "C:\\Users\\bravefe999\\AppData\\Local\\Temp\\ipykernel_2916\\2940091877.py:10: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "  print('4 is 2 ** 2:', 4 is 2 ** 2)   # True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Another way comparison\n",
+    "# True - because the data values are the same\n",
+    "print('1 is 1', 1 is 1)\n",
+    "print('1 is not 2', 1 is not 2)           # True - because 1 is not 2\n",
+    "print('A in Asabeneh', 'A' in 'Asabeneh')  # True - A found in the string\n",
+    "print('B in Asabeneh', 'B' in 'Asabeneh')  # False -there is no uppercase B\n",
+    "# True - because coding for all has the word coding\n",
+    "print('coding' in 'coding for all')\n",
+    "print('a in an:', 'a' in 'an')      # True\n",
+    "print('4 is 2 ** 2:', 4 is 2 ** 2)   # True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c5149d87",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n",
+      "False\n",
+      "True\n",
+      "True\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "True\n",
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(3 > 2 and 4 > 3)  # True - because both statements are true\n",
+    "print(3 > 2 and 4 < 3)  # False - because the second statement is false\n",
+    "print(3 < 2 and 4 < 3)  # False - because both statements are false\n",
+    "print(3 > 2 or 4 > 3)  # True - because both statements are true\n",
+    "print(3 > 2 or 4 < 3)  # True - because one of the statement is true\n",
+    "print(3 < 2 or 4 < 3)  # False - because both statements are false\n",
+    "print(not 3 > 2)     # False - because 3 > 2 is true, then not True gives False\n",
+    "print(not True)      # False - Negation, the not operator turns true to false\n",
+    "print(not False)     # True\n",
+    "print(not not True)  # True\n",
+    "print(not not False)  # False"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.11.15)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/04_Day_Strings/day_4.ipynb
+++ b/04_Day_Strings/day_4.ipynb
@@ -1,0 +1,795 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7cbc22e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P\n",
+      "1\n",
+      "Hello, World!\n",
+      "13\n",
+      "I hope you are enjoying 30 days of python challenge\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Single line comment\n",
+    "letter = 'P'                # A string could be a single character or a bunch of texts\n",
+    "print(letter)               # P\n",
+    "print(len(letter))          # 1\n",
+    "greeting = 'Hello, World!'  # String could be  a single or double quote,\"Hello, World!\"\n",
+    "print(greeting)             # Hello, World!\n",
+    "print(len(greeting))        # 13\n",
+    "sentence = \"I hope you are enjoying 30 days of python challenge\"\n",
+    "print(sentence)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "89ff299d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I am a teacher and enjoy teaching.\n",
+      "I didn't find anything as rewarding as empowering people.\n",
+      "That is why I created 30 days of python.\n",
+      "I am a teacher and enjoy teaching.\n",
+      "I didn't find anything as rewarding as empowering people.\n",
+      "That is why I created 30 days of python.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Multiline String\n",
+    "multiline_string = '''I am a teacher and enjoy teaching.\n",
+    "I didn't find anything as rewarding as empowering people.\n",
+    "That is why I created 30 days of python.'''\n",
+    "print(multiline_string)\n",
+    "# Another way of doing the same thing\n",
+    "multiline_string = \"\"\"I am a teacher and enjoy teaching.\n",
+    "I didn't find anything as rewarding as empowering people.\n",
+    "That is why I created 30 days of python.\"\"\"\n",
+    "print(multiline_string)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f2832ee7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Asabeneh Yetayeh\n",
+      "8\n",
+      "7\n",
+      "True\n",
+      "16\n"
+     ]
+    }
+   ],
+   "source": [
+    "# String Concatenation\n",
+    "first_name = 'Asabeneh'\n",
+    "last_name = 'Yetayeh'\n",
+    "space = ' '\n",
+    "full_name = first_name + space + last_name\n",
+    "print(full_name)  # Asabeneh Yetayeh\n",
+    "# Checking length of a string using len() builtin function\n",
+    "print(len(first_name))  # 8\n",
+    "print(len(last_name))   # 7\n",
+    "print(len(first_name) > len(last_name))  # True\n",
+    "print(len(full_name))  # 15"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "79cd6894",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P\n",
+      "y\n",
+      "t\n",
+      "h\n",
+      "o\n",
+      "n\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Unpacking characters\n",
+    "language = 'Python'\n",
+    "a, b, c, d, e, f = language  # unpacking sequence characters into variables\n",
+    "print(a)  # P\n",
+    "print(b)  # y\n",
+    "print(c)  # t\n",
+    "print(d)  # h\n",
+    "print(e)  # o\n",
+    "print(f)  # n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1c8ac4c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P\n",
+      "y\n",
+      "n\n",
+      "n\n",
+      "o\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Accessing characters in strings by index\n",
+    "language = 'Python'\n",
+    "first_letter = language[0]\n",
+    "print(first_letter)  # P\n",
+    "second_letter = language[1]\n",
+    "print(second_letter)  # y\n",
+    "last_index = len(language) - 1\n",
+    "last_letter = language[last_index]\n",
+    "print(last_letter)  # n\n",
+    "\n",
+    "# If we want to start from right end we can use negative indexing. -1 is the last index\n",
+    "language = 'Python'\n",
+    "last_letter = language[-1]\n",
+    "print(last_letter)  # n\n",
+    "second_last = language[-2]\n",
+    "print(second_last)  # o\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6fd4f5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pyt\n",
+      "hon\n",
+      "hon\n",
+      "hon\n",
+      "Pto\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Slicing\n",
+    "\n",
+    "language = 'Python'\n",
+    "# starts at zero index and up to 3 but not include 3\n",
+    "first_three = language[0:3]\n",
+    "print(first_three)  # Pyt\n",
+    "last_three = language[3:6]\n",
+    "print(last_three)  # hon\n",
+    "# Another way\n",
+    "last_three = language[-3:]\n",
+    "print(last_three)   # hon\n",
+    "last_three = language[3:]\n",
+    "print(last_three)   # hon\n",
+    "\n",
+    "# Skipping character while splitting Python strings\n",
+    "language = 'Python'\n",
+    "pto = language[0:6:2]\n",
+    "print(pto)  # pto"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "535597cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I hope every one enjoying the python challenge.\n",
+      "Do you ?\n",
+      "Days\tTopics\tExercises\n",
+      "Day 1\t3\t5\n",
+      "Day 2\t3\t5\n",
+      "Day 3\t3\t5\n",
+      "Day 4\t3\t5\n",
+      "This is a back slash  symbol (\\)\n",
+      "In every programming language it starts with \"Hello, World!\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Escape sequence\n",
+    "print('I hope every one enjoying the python challenge.\\nDo you ?')  # line break\n",
+    "print('Days\\tTopics\\tExercises')\n",
+    "print('Day 1\\t3\\t5')\n",
+    "print('Day 2\\t3\\t5')\n",
+    "print('Day 3\\t3\\t5')\n",
+    "print('Day 4\\t3\\t5')\n",
+    "print('This is a back slash  symbol (\\\\)')  # To write a back slash\n",
+    "print('In every programming language it starts with \\\"Hello, World!\\\"')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77c1d8d9",
+   "metadata": {},
+   "source": [
+    "# String Methods"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "297b3d8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Thirty days of python\n"
+     ]
+    }
+   ],
+   "source": [
+    "# capitalize(): Converts the first character the string to Capital Letter\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.capitalize())  # 'Thirty days of python'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f93838c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3\n",
+      "1\n",
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# count(): returns occurrences of substring in string, count(substring, start=.., end=..)\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.count('y'))  # 3\n",
+    "# count y between 7th and 14th index\n",
+    "print(challenge.count('y', 7, 14))  # 1 \n",
+    "print(challenge.count('th'))  # 2`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "1cd5ee39",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# endswith(): Checks if a string ends with a specified ending\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.endswith('on'))   # True\n",
+    "print(challenge.endswith('tion'))  # False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "430644f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "thirty  days    of      python\n",
+      "thirty    days      of        python\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# expandtabs(): Replaces tab character with spaces, default tab size is 8. It takes tab size argument\n",
+    "\n",
+    "challenge = 'thirty\\tdays\\tof\\tpython'\n",
+    "print(challenge.expandtabs())   # 'thirty  days    of      python'\n",
+    "print(challenge.expandtabs(10))  # 'thirty    days      of        python'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0914ea2a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n",
+      "0\n",
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# find(): Returns the index of first occurrence of substring\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.find('y'))  # 5\n",
+    "print(challenge.find('th'))  # 0\n",
+    "print(challenge.find('ir'))  # 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2d03d9e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I am Asabeneh Yetayeh. I am a teacher. I live in Finland.\n",
+      "The area of circle with 10 is 3.14\n"
+     ]
+    }
+   ],
+   "source": [
+    "# format()\tformats string into nicer output\n",
+    "first_name = 'Asabeneh'\n",
+    "last_name = 'Yetayeh'\n",
+    "job = 'teacher'\n",
+    "country = 'Finland'\n",
+    "sentence = 'I am {} {}. I am a {}. I live in {}.'.format(\n",
+    "    first_name, last_name, job, country)\n",
+    "print(sentence)  # I am Asabeneh Yetayeh. I am a teacher. I live in Finland.\n",
+    "\n",
+    "radius = 10\n",
+    "pi = 3.14\n",
+    "area = pi  # radius ## 2\n",
+    "result = 'The area of circle with {} is {}'.format(str(radius), str(area))\n",
+    "print(result)  # The area of circle with 10 is 314.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e6e3e8f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n",
+      "0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# index(): Returns the index of substring\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.find('y'))  # 5\n",
+    "print(challenge.find('th'))  # 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "be6cb006",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "True\n",
+      "False\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# isalnum(): Checks alphanumeric character\n",
+    "\n",
+    "challenge = 'ThirtyDaysPython'\n",
+    "print(challenge.isalnum())  # True\n",
+    "\n",
+    "challenge = '30DaysPython'\n",
+    "print(challenge.isalnum())  # True\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.isalnum())  # False\n",
+    "\n",
+    "challenge = 'thirty days of python 2019'\n",
+    "print(challenge.isalnum())  # False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "a8aa2e1b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# isalpha(): Checks if all characters are alphabets\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.isalpha())  # True\n",
+    "num = '123'\n",
+    "print(num.isalpha())      # False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "1041dd50",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# isdigit(): Checks Digit Characters\n",
+    "\n",
+    "challenge = 'Thirty'\n",
+    "print(challenge.isdigit())  # False\n",
+    "challenge = '30'\n",
+    "print(challenge.isdigit())   # True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3fb1a58",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# isdecimal():Checks decimal characters\n",
+    "\n",
+    "num = '10'\n",
+    "print(num.isdecimal())  # True\n",
+    "num = '10.5'\n",
+    "print(num.isdecimal())  # False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "8eede3b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# isidentifier():Checks for valid identifier means it check if a string is a valid variable name\n",
+    "\n",
+    "challenge = '30DaysOfPython'\n",
+    "print(challenge.isidentifier())  # False, because it starts with a number\n",
+    "challenge = 'thirty_days_of_python'\n",
+    "print(challenge.isidentifier())  # True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "1c445570",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# islower():Checks if all alphabets in a string are lowercase\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.islower())  # True\n",
+    "challenge = 'Thirty days of python'\n",
+    "print(challenge.islower())  # False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "685e316d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# isupper(): returns if all characters are uppercase characters\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.isupper())  # False\n",
+    "challenge = 'THIRTY DAYS OF PYTHON'\n",
+    "print(challenge.isupper())  # True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "e7296d25",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# isnumeric():Checks numeric characters\n",
+    "\n",
+    "num = '10'\n",
+    "print(num.isnumeric())      # True\n",
+    "print('ten'.isnumeric())    # False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "ca437ca6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HTML#, CSS#, JavaScript#, React\n"
+     ]
+    }
+   ],
+   "source": [
+    "# join(): Returns a concatenated string\n",
+    "\n",
+    "web_tech = ['HTML', 'CSS', 'JavaScript', 'React']\n",
+    "result = '#, '.join(web_tech)\n",
+    "print(result)  # 'HTML# CSS# JavaScript# React'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "32a1311b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " thirty days of python \n"
+     ]
+    }
+   ],
+   "source": [
+    "# strip(): Removes both leading and trailing characters\n",
+    "\n",
+    "challenge = ' thirty days of python '\n",
+    "print(challenge.strip('y'))  # 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "cff77c4a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "thirty days of coding\n"
+     ]
+    }
+   ],
+   "source": [
+    "# replace(): Replaces substring inside\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.replace('python', 'coding'))  # 'thirty days of coding'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "1fe9caef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['thirty', 'days', 'of', 'python']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# split():Splits String from Left\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.split())  # ['thirty', 'days', 'of', 'python']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "bacc1028",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Thirty Days Of Python\n"
+     ]
+    }
+   ],
+   "source": [
+    "# title(): Returns a Title Cased String\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.title())  # Thirty Days Of Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "7f453149",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "THIRTY DAYS OF PYTHON\n",
+      "tHIRTY dAYS oF pYTHON\n"
+     ]
+    }
+   ],
+   "source": [
+    "# swapcase(): Checks if String Starts with the Specified String\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.swapcase())   # THIRTY DAYS OF PYTHON\n",
+    "challenge = 'Thirty Days Of Python'\n",
+    "print(challenge.swapcase())  # tHIRTY dAYS oF pYTHON"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "933385a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# startswith(): Checks if String Starts with the Specified String\n",
+    "\n",
+    "challenge = 'thirty days of python'\n",
+    "print(challenge.startswith('thirty'))  # True\n",
+    "challenge = '30 days of python'\n",
+    "print(challenge.startswith('thirty'))  # False"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.11.15)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/04_Day_Strings/day_4.py
+++ b/04_Day_Strings/day_4.py
@@ -159,11 +159,6 @@ print(challenge.isalpha())  # True
 num = '123'
 print(num.isalpha())      # False
 
-# isdecimal(): Checks Decimal Characters
-
-challenge = 'thirty days of python'
-print(challenge.find('y'))  # 5
-print(challenge.find('th'))  # 0
 
 # isdigit(): Checks Digit Characters
 

--- a/05_Day_Lists/day_5.ipynb
+++ b/05_Day_Lists/day_5.ipynb
@@ -1,0 +1,543 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fded2e94",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n"
+     ]
+    }
+   ],
+   "source": [
+    "empty_list = list()  # this is an empty list, no item in the list\n",
+    "print(len(empty_list))  # 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a998a4cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fruits: ['banana', 'orange', 'mango', 'lemon']\n",
+      "Number of fruits: 4\n",
+      "Vegetables: ['Tomato', 'Potato', 'Cabbage', 'Onion', 'Carrot']\n",
+      "Number of vegetables: 5\n",
+      "Animal products: ['milk', 'meat', 'butter', 'yoghurt']\n",
+      "Number of animal products: 4\n",
+      "Web technologies: ['HTML', 'CSS', 'JS', 'React', 'Redux', 'Node', 'MongDB']\n",
+      "Number of web technologies: 7\n",
+      "Number of countries: 5\n"
+     ]
+    }
+   ],
+   "source": [
+    "# list of fruits\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "vegetables = ['Tomato', 'Potato', 'Cabbage',\n",
+    "              'Onion', 'Carrot']      # list of vegetables\n",
+    "animal_products = ['milk', 'meat', 'butter',\n",
+    "                   'yoghurt']             # list of animal products\n",
+    "web_techs = ['HTML', 'CSS', 'JS', 'React', 'Redux',\n",
+    "             'Node', 'MongDB']  # list of web technologies\n",
+    "countries = ['Finland', 'Estonia', 'Denmark', 'Sweden', 'Norway']\n",
+    "\n",
+    "# Print the lists and it length\n",
+    "print('Fruits:', fruits)\n",
+    "print('Number of fruits:', len(fruits))\n",
+    "print('Vegetables:', vegetables)\n",
+    "print('Number of vegetables:', len(vegetables))\n",
+    "print('Animal products:', animal_products)\n",
+    "print('Number of animal products:', len(animal_products))\n",
+    "print('Web technologies:', web_techs)\n",
+    "print('Number of web technologies:', len(web_techs))\n",
+    "print('Number of countries:', len(countries))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d3b7f1d",
+   "metadata": {},
+   "source": [
+    "# Modifying list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "mod-1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "banana\n",
+      "orange\n",
+      "lemon\n"
+     ]
+    }
+   ],
+   "source": [
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "first_fruit = fruits[0]  # we are accessing the first item using its index\n",
+    "print(first_fruit)      # banana\n",
+    "second_fruit = fruits[1]\n",
+    "print(second_fruit)     # orange\n",
+    "last_fruit = fruits[3]\n",
+    "print(last_fruit)  # lemon\n",
+    "# Last index\n",
+    "last_index = len(fruits) - 1\n",
+    "last_fruit = fruits[last_index]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "mod-2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lemon\n",
+      "mango\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Accessing items\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "last_fruit = fruits[-1]\n",
+    "second_last = fruits[-2]\n",
+    "print(last_fruit)       # lemon\n",
+    "print(second_last)      # mango"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "mod-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Slicing items\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "all_fruits = fruits[0:4]  # it returns all the fruits\n",
+    "all_fruits = fruits[0:]  # if we don't set where to stop it takes all the rest\n",
+    "orange_and_mango = fruits[1:3]  # it does not include the end index\n",
+    "orange_mango_lemon = fruits[1:]\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "all_fruits = fruits[-4:]  # it returns all the fruits\n",
+    "orange_and_mango = fruits[-3:-1]  # it does not include the end index\n",
+    "orange_mango_lemon = fruits[-3:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mod-4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Avocado', 'orange', 'mango', 'lemon']\n",
+      "['Avocado', 'apple', 'mango', 'lemon']\n",
+      "['Avocado', 'apple', 'mango', 'lime']\n"
+     ]
+    }
+   ],
+   "source": [
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits[0] = 'Avocado'\n",
+    "print(fruits)  # ['avocado', 'orange', 'mango', 'lemon']\n",
+    "fruits[1] = 'apple'\n",
+    "print(fruits)  # ['avocado', 'apple', 'mango', 'lemon']\n",
+    "last_index = len(fruits) - 1\n",
+    "fruits[last_index] = 'lime'\n",
+    "print(fruits)  # ['avocado', 'apple', 'mango', 'lime']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "mod-5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# checking items\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "does_exist = 'banana' in fruits\n",
+    "print(does_exist)  # True\n",
+    "does_exist = 'lime' in fruits\n",
+    "print(does_exist)  # False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "mod-6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['banana', 'orange', 'mango', 'lemon', 'apple']\n",
+      "['banana', 'orange', 'mango', 'lemon', 'apple', 'lime']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Append\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits.append('apple')\n",
+    "print(fruits)           # ['banana', 'orange', 'mango', 'lemon', 'apple']\n",
+    "fruits.append('lime')\n",
+    "print(fruits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mod-7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['banana', 'orange', 'apple', 'mango', 'lemon']\n",
+      "['banana', 'orange', 'apple', 'lime', 'mango', 'lemon']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# insert\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits.insert(2, 'apple')  # insert apple between orange and mango\n",
+    "print(fruits)           # ['banana', 'orange', 'apple', 'mango', 'lemon']\n",
+    "fruits.insert(3, 'lime')\n",
+    "print(fruits)           # ['banana', 'orange', 'apple', 'lime', 'mango', 'lemon']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "mod-8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['orange', 'mango', 'lemon']\n",
+      "['orange', 'mango']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# remove\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits.remove('banana')\n",
+    "print(fruits)  # ['orange', 'mango', 'lemon']\n",
+    "fruits.remove('lemon')\n",
+    "print(fruits)  # ['orange', 'mango']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "mod-9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['banana', 'orange', 'mango']\n",
+      "['orange', 'mango']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# pop\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits.pop()\n",
+    "print(fruits)       # ['banana', 'orange', 'mango']\n",
+    "fruits.pop(0)\n",
+    "print(fruits)       # ['orange', 'mango']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "mod-10",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['orange', 'mango', 'lemon']\n",
+      "['orange', 'lemon']\n"
+     ]
+    },
+    {
+     "ename": "NameError",
+     "evalue": "name 'fruits' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[18]\u001b[39m\u001b[32m, line 8\u001b[39m\n\u001b[32m      4\u001b[39m print(fruits)       \u001b[38;5;66;03m# ['orange', 'mango', 'lemon']\u001b[39;00m\n\u001b[32m      5\u001b[39m \u001b[38;5;28;01mdel\u001b[39;00m fruits[\u001b[32m1\u001b[39m]\n\u001b[32m      6\u001b[39m print(fruits)       \u001b[38;5;66;03m# ['orange', 'lemon']\u001b[39;00m\n\u001b[32m      7\u001b[39m \u001b[38;5;28;01mdel\u001b[39;00m fruits\n\u001b[32m----> \u001b[39m\u001b[32m8\u001b[39m print(fruits)       \u001b[38;5;66;03m# This should give: NameError: name 'fruits' is not defined\u001b[39;00m\n",
+      "\u001b[31mNameError\u001b[39m: name 'fruits' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "# del\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "del fruits[0]\n",
+    "print(fruits)       # ['orange', 'mango', 'lemon']\n",
+    "del fruits[1]\n",
+    "print(fruits)       # ['orange', 'lemon']\n",
+    "del fruits\n",
+    "print(fruits)       # This should give: NameError: name 'fruits' is not defined"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "mod-11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n",
+      "['banana', 'orange', 'mango', 'lemon']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# clear\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits.clear()\n",
+    "print(fruits)       # []\n",
+    "# copying a lits\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits_copy = fruits.copy()\n",
+    "print(fruits_copy)       # ['banana', 'orange', 'mango', 'lemon']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "mod-12",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]\n",
+      "['banana', 'orange', 'mango', 'lemon', 'Tomato', 'Potato', 'Cabbage', 'Onion', 'Carrot']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# join\n",
+    "positive_numbers = [1, 2, 3, 4, 5]\n",
+    "zero = [0]\n",
+    "negative_numbers = [-5, -4, -3, -2, -1]\n",
+    "integers = negative_numbers + zero + positive_numbers\n",
+    "print(integers)\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "vegetables = ['Tomato', 'Potato', 'Cabbage', 'Onion', 'Carrot']\n",
+    "fruits_and_vegetables = fruits + vegetables\n",
+    "print(fruits_and_vegetables)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "mod-13",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Numbers: [0, 1, 2, 3, 4, 5, 6]\n",
+      "Integers: [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]\n",
+      "Fruits and vegetables: ['banana', 'orange', 'mango', 'lemon', 'Tomato', 'Potato', 'Cabbage', 'Onion', 'Carrot']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# join with extend\n",
+    "num1 = [0, 1, 2, 3]\n",
+    "num2 = [4, 5, 6]\n",
+    "num1.extend(num2)\n",
+    "print('Numbers:', num1)\n",
+    "negative_numbers = [-5, -4, -3, -2, -1]\n",
+    "positive_numbers = [1, 2, 3, 4, 5]\n",
+    "zero = [0]\n",
+    "negative_numbers.extend(zero)\n",
+    "negative_numbers.extend(positive_numbers)\n",
+    "print('Integers:', negative_numbers)\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "vegetables = ['Tomato', 'Potato', 'Cabbage', 'Onion', 'Carrot']\n",
+    "fruits.extend(vegetables)\n",
+    "print('Fruits and vegetables:', fruits)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "mod-14",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# count\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "print(fruits.count('orange'))   # 1\n",
+    "ages = [22, 19, 24, 25, 26, 24, 25, 24]\n",
+    "print(ages.count(24))           # 3\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "mod-15",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# index\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "print(fruits.index('orange'))   # 1\n",
+    "ages = [22, 19, 24, 25, 26, 24, 25, 24]\n",
+    "print(ages.index(24))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "mod-16",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n",
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reverse\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits.reverse()\n",
+    "print(fruits.reverse())\n",
+    "ages = [22, 19, 24, 25, 26, 24, 25, 24]\n",
+    "ages.reverse()\n",
+    "print(ages.reverse())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "mod-17",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['banana', 'lemon', 'mango', 'orange']\n",
+      "['orange', 'mango', 'lemon', 'banana']\n",
+      "[19, 22, 24, 24, 24, 25, 25, 26]\n",
+      "[26, 25, 25, 24, 24, 24, 22, 19]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# sort\n",
+    "fruits = ['banana', 'orange', 'mango', 'lemon']\n",
+    "fruits.sort()\n",
+    "print(fruits)\n",
+    "fruits.sort(reverse=True)\n",
+    "print(fruits)\n",
+    "ages = [22, 19, 24, 25, 26, 24, 25, 24]\n",
+    "ages.sort()\n",
+    "print(ages)\n",
+    "ages.sort(reverse=True)\n",
+    "print(ages)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.11.15)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/05_Day_Lists/day_5.py
+++ b/05_Day_Lists/day_5.py
@@ -62,7 +62,7 @@ fruits[0] = 'Avocado'
 print(fruits)  # ['avocado', 'orange', 'mango', 'lemon']
 fruits[1] = 'apple'
 print(fruits)  # ['avocado', 'apple', 'mango', 'lemon']
-last_index = len(fruits)
+last_index = len(fruits) - 1
 fruits[last_index] = 'lime'
 print(fruits)  # ['avocado', 'apple', 'mango', 'lime']
 


### PR DESCRIPTION
## Before

The file contained an incorrect duplicate `isdecimal()` section at line 162:

```python
# isdecimal(): Checks Decimal Characters

challenge = 'thirty days of python'
print(challenge.find('y'))  # 5
print(challenge.find('th'))  # 0
```

This section is actually demonstrating the `find()` method, not `isdecimal()`.

Additionally, `find()` is already covered at line 115:

```python
# find(): Returns the index of first occurrence of substring

challenge = 'thirty days of python'
print(challenge.find('y'))  # 5
print(challenge.find('th'))  # 0
```

The actual `isdecimal()` example is correctly included at line 175:

```python
# isdecimal(): Checks decimal characters

num = '10'
print(num.isdecimal())  # True
num = '10.5'
print(num.isdecimal())  # False
```

## Change made

Removed the duplicate and incorrectly labeled `isdecimal()` section at line 162, since:

1. It contains `find()` examples rather than `isdecimal()` examples.
2. `find()` is already demonstrated at line 115.
3. The correct `isdecimal()` example remains at line 175->169.

This removes the unnecessary duplication and keeps each string method example in its appropriate section.