### PR TITLE
Fix type print statement for tuple and set

### DIFF
--- a/01_Day_Introduction/helloworld.py
+++ b/01_Day_Introduction/helloworld.py
@@ -21,5 +21,6 @@ print(type(3.14))                # Float
 print(type(1 + 3j))              # Complex
 print(type('Asabeneh'))          # String
 print(type([1, 2, 3]))           # List
+print(type((1, 2, 3)))           # Tuple
 print(type({'name': 'Asabeneh'}))  # Dictionary
-print(type({9.8, 3.14, 2.7}))    # Tuple
+print(type({9.8, 3.14, 2.7}))    # Set


### PR DESCRIPTION
### Description
This PR corrects the inline comments for the data type print statements in `01_Day_Introduction/helloworld.py`. 

### Changes Made
- Added the missing `print(type((1, 2, 3))) # Tuple` example.
- Corrected the comment on the set example from `# Tuple` to `# Set` to accurately match the data structure used (`{9.8, 3.14, 2.7}`).

These updates ensure that beginners following the 30-Days-Of-Python guide see the correct visual examples for both tuples and sets and not getting them confused on their first encounter with the programing language.